### PR TITLE
bugfix: Create JWK provisioner

### DIFF
--- a/plugins/module_utils/provisioner.py
+++ b/plugins/module_utils/provisioner.py
@@ -198,7 +198,16 @@ class StepCAContext:
             RuntimeError: If the CLI command fails.
         """
         command = self._extend_command(
-            ["step", "ca", "provisioner", "add", name, "--type", provisioner_type]
+            [
+                "step",
+                "ca",
+                "provisioner",
+                "add",
+                name,
+                "--type",
+                provisioner_type,
+                "--create",
+            ]
         )
 
         # Add specific X509 duration parameters if provided


### PR DESCRIPTION
Creating a JWK provisioner needs an additional argument `--create` passed to the step command.

This addition does not affect ACME providers