### PR TITLE
feat(provisioner): add optional password parameter with secure generation

### DIFF
--- a/plugins/module_utils/provisioner.py
+++ b/plugins/module_utils/provisioner.py
@@ -198,7 +198,16 @@ class StepCAContext:
             RuntimeError: If the CLI command fails.
         """
         command = self._extend_command(
-            ["step", "ca", "provisioner", "add", name, "--type", provisioner_type]
+            [
+                "step",
+                "ca",
+                "provisioner",
+                "add",
+                name,
+                "--type",
+                provisioner_type,
+                "--create",
+            ]
         )
 
         # Add specific X509 duration parameters if provided

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -1,6 +1,8 @@
 """Utility functions for working with the 'step' command."""
 
 import json
+import secrets
+import string
 from pathlib import Path
 from typing import Tuple, Optional, Dict, Any
 
@@ -20,6 +22,38 @@ def get_step_path() -> str:
     """
     result = run_command(["step", "path"], check=True)
     return result.stdout.strip()
+
+
+def generate_secure_password(length: int = 32) -> str:
+    """Generate a cryptographically secure random password.
+
+    The password includes uppercase and lowercase letters, digits,
+    and special characters to ensure high security standards.
+
+    Args:
+        length: The length of the password to generate (default: 32).
+
+    Returns:
+        str: A secure random password.
+    """
+    # Define character sets for password complexity
+    alphabet = string.ascii_letters + string.digits + "!@#$%^&*()-_=+[]{}|;:,.<>?"
+
+    # Ensure at least one of each character type for complexity requirements
+    password = [
+        secrets.choice(string.ascii_uppercase),
+        secrets.choice(string.ascii_lowercase),
+        secrets.choice(string.digits),
+        secrets.choice("!@#$%^&*()-_=+[]{}|;:,.<>?"),
+    ]
+
+    # Fill the rest of the password with random characters
+    password.extend(secrets.choice(alphabet) for _ in range(length - 4))
+
+    # Shuffle the password to randomize character positions
+    secrets.SystemRandom().shuffle(password)
+
+    return "".join(password)
 
 
 def read_json_file(json_file: str) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:


### PR DESCRIPTION
Add support for optional password parameter to the provisioner module. If no 
password is provided when adding a non-ACME provisioner, a secure password 
is automatically generated using the new generate_secure_password utility 
function.

- Add password parameter to provisioner module with appropriate documentation
- Create reusable secure password generation utility function in utils.py
- Handle password file permissions securely with proper owner and 0600 permissions
- Skip password generation for ACME provisioners which don't require it
- Return generated password to playbook for reference when auto-generated