### PR TITLE
style(docs): fix docstring formatting to comply with flake8-docstrings

### DIFF
--- a/plugins/module_utils/__init__.py
+++ b/plugins/module_utils/__init__.py
@@ -1,0 +1,1 @@
+"""Package containing utility modules for plugins."""

--- a/plugins/module_utils/process.py
+++ b/plugins/module_utils/process.py
@@ -43,6 +43,8 @@ def strip_ansi_sequences(text):
 
 def sanitize_output(text: Optional[str], strip_ansi: bool = True) -> Optional[str]:
     """
+    Sanitize command output.
+
     Sanitize command output by optionally stripping ANSI sequences
     and performing additional safety checks.
 

--- a/plugins/module_utils/provisioner.py
+++ b/plugins/module_utils/provisioner.py
@@ -1,4 +1,6 @@
 """
+Step CA provisioner dataclasses.
+
 This module defines dataclasses and helper classes for managing
 Step CA provisioners.
 

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -57,7 +57,7 @@ def generate_secure_password(length: int = 32) -> str:
 
 
 def read_json_file(json_file: str) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
-    """Reads and parses a JSON configuration file.
+    """Read and parses a JSON configuration file.
 
     Args:
         json_file: Path to the JSON file.

--- a/plugins/modules/bootstrap.py
+++ b/plugins/modules/bootstrap.py
@@ -1,3 +1,10 @@
+"""
+Bootstrap a node with step-ca root certificate.
+
+This Ansible module bootstraps a step-ca node by installing the root certificates
+and optionally installing the step-cli tool.
+"""
+
 from ansible.module_utils.basic import AnsibleModule
 from ansible_collections.matonb.step.plugins.module_utils.utils import (
     read_json_file,
@@ -5,7 +12,7 @@ from ansible_collections.matonb.step.plugins.module_utils.utils import (
 
 
 def main():
-    """Main function for the Ansible module."""
+    """Run the Ansible module."""
     module_args = {
         "config_file": {"type": "str", "required": True}
     }

--- a/plugins/modules/configure.py
+++ b/plugins/modules/configure.py
@@ -1,5 +1,5 @@
 """
-Ansible module for manipulating step configuration JSON files.
+Modify a step-ca configuration JSON file with provided updates.
 
 This module takes a JSON file path and a dictionary of updates,
 modifies the JSON file, and saves the changes.
@@ -37,7 +37,7 @@ def save_json_file(json_path, data):
 
 
 def main():
-    """Main function to execute the Ansible module logic."""
+    """Run the Ansible module."""
     module_args = {
         "ca_config": {
             "type": "path", "required": False, "default": None

--- a/plugins/modules/initialize.py
+++ b/plugins/modules/initialize.py
@@ -1,4 +1,4 @@
-"""Ansible module to initialize a Step CA instance."""
+"""Initialize a Step CA instance."""
 
 import os
 import pathlib
@@ -331,7 +331,7 @@ def run_step_ca_initialize(module: AnsibleModule) -> None:
 
 
 def main() -> None:
-    """Main entry point for the Ansible module."""
+    """Run the Ansible module."""
     module = AnsibleModule(argument_spec=get_argument_spec(), supports_check_mode=True)
 
     # Ensure STEPPATH is set when we invoke the step command

--- a/plugins/modules/provisioner.py
+++ b/plugins/modules/provisioner.py
@@ -1,7 +1,7 @@
 """
-Ansible module for managing step-ca provisioners.
+Manage step-ca provisioners.
 
-This module allows creating, removing, and querying provisioners
+This Ansible module allows creating, removing, and querying provisioners
 in a step-ca certificate authority. It supports different provisioner
 types including JWK and ACME.
 """
@@ -230,7 +230,7 @@ def get_argument_spec() -> dict:
 
 
 def main() -> None:
-    """Main entry point for the provisioner Ansible module."""
+    """Run the Ansible module."""
     module = AnsibleModule(argument_spec=get_argument_spec(), supports_check_mode=True)
 
     name = module.params["name"]


### PR DESCRIPTION
Fix various docstring issues including:
- Add missing docstrings to __init__.py files
- Convert docstrings to imperative mood (D401)
- Fix blank line spacing between summary and descriptions
- Ensure summary lines end with periods