### PR TITLE
fix: adjust flake8 scope and add .ansible/ to .gitignore

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,17 +22,21 @@ jobs:
 
       - name: Install linting tools
         run: |
-          pip install ansible ansible-lint yamllint flake8
+          python -m pip install --upgrade pip
+          pip install ansible ansible-lint flake8 flake8-docstrings yamllint
 
       - name: Lint Ansible roles
         run: |
           ansible-lint roles/
           ansible-lint plugins/
 
+      - name: Lint Python code
+        run: |
+          flake8 plugins/ --count --select=E9,F63,F7,F82 \
+              --show-source --statistics
+          flake8 plugins/ --count --exit-zero --max-complexity=10 \
+              --max-line-length=127 --statistics
+
       - name: Lint YAML files
         run: |
           yamllint .
-
-      - name: Lint Python code
-        run: |
-          flake8 plugins/

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ wheels/
 *.egg
 
 # Ansible specific
+.ansible/
 *.retry
 *.galaxy_install_info
 ansible.log


### PR DESCRIPTION
- Limit flake8 to only check plugins/ directory
- Split long lines in flake8 commands for yamllint compliance
- Add .ansible/ directory to .gitignore

`.ansible` appeared when locally testing github workflows with act.