### PR TITLE
build: migrate from flake8 to comprehensive ruff configuration

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-max-line-length = 122
-extend-ignore = E203, W503
-exclude = __pycache__,*.pyc,.venv
-

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install linting tools
         run: |
           python -m pip install --upgrade pip
-          pip install ansible ansible-lint flake8 flake8-docstrings yamllint
+          pip install ansible ansible-lint ruff yamllint
 
       - name: Lint Ansible roles
         run: |
@@ -32,10 +32,8 @@ jobs:
 
       - name: Lint Python code
         run: |
-          flake8 plugins/ --count --select=E9,F63,F7,F82 \
-              --show-source --statistics
-          flake8 plugins/ --count --exit-zero --max-complexity=10 \
-              --max-line-length=127 --statistics
+          ruff check plugins/
+          ruff format --check plugins/
 
       - name: Lint YAML files
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.12.1
+  hooks:
+  - id: ruff
+    name: ruff (config validation)
+    description: Validate ruff configuration
+    args: [ check, --show-settings, plugins/ ]
+    pass_filenames: false
+  - id: ruff
+    name: ruff (linter)
+    description: Run ruff linter
+    args: [ --fix ]
+  - id: ruff-format
+    name: ruff (formatter)
+    description: Run ruff formatter

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,35 @@
+---
 repos:
-- repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.1
-  hooks:
-  - id: ruff
-    name: ruff (config validation)
-    description: Validate ruff configuration
-    args: [ check, --show-settings, plugins/ ]
-    pass_filenames: false
-  - id: ruff
-    name: ruff (linter)
-    description: Run ruff linter
-    args: [ --fix ]
-  - id: ruff-format
-    name: ruff (formatter)
-    description: Run ruff formatter
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.1
+    hooks:
+      - id: ruff
+        name: ruff (config validation)
+        description: Validate ruff configuration
+        args: [check, --show-settings, plugins/]
+        pass_filenames: false
+      - id: ruff
+        name: ruff (linter)
+        description: Run ruff linter
+        args: [--fix]
+      - id: ruff-format
+        name: ruff (formatter)
+        description: Run ruff formatter
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        name: yamllint
+        description: Lint YAML files
+        args: [--format, parsable]
+
+# Disabled for now - requires more complex configuration for collection metadata
+#  - repo: https://github.com/ansible/ansible-lint
+#    rev: v24.12.2
+#    hooks:
+#      - id: ansible-lint
+#        name: ansible-lint
+#        description: Lint Ansible files
+#        files: ^(roles|playbooks)/.*\.(ya?ml)$
+#        additional_dependencies: [ansible-core]

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -4,7 +4,7 @@ import json
 import secrets
 import string
 from pathlib import Path
-from typing import Tuple, Optional, Dict, Any
+from typing import Any, Optional
 
 from .process import run_command
 
@@ -56,7 +56,7 @@ def generate_secure_password(length: int = 32) -> str:
     return "".join(password)
 
 
-def read_json_file(json_file: str) -> Tuple[Optional[Dict[str, Any]], Optional[str]]:
+def read_json_file(json_file: str) -> tuple[Optional[dict[str, Any]], Optional[str]]:
     """Read and parses a JSON configuration file.
 
     Args:
@@ -86,7 +86,7 @@ def read_json_file(json_file: str) -> Tuple[Optional[Dict[str, Any]], Optional[s
         return None, f"Invalid data in file: {value_error}"
 
 
-def save_json_file(json_path: str, data: Dict[str, Any]) -> Dict[str, Any]:
+def save_json_file(json_path: str, data: dict[str, Any]) -> dict[str, Any]:
     """Save JSON data to a file.
 
     Args:
@@ -99,6 +99,6 @@ def save_json_file(json_path: str, data: Dict[str, Any]) -> Dict[str, Any]:
     try:
         with open(json_path, "w", encoding=ENCODING) as file:
             json.dump(data, file, indent=4)
-    except IOError as error:
+    except OSError as error:
         return {"error": f"Failed to write JSON file: {str(error)}"}
     return {"success": True}

--- a/plugins/modules/bootstrap.py
+++ b/plugins/modules/bootstrap.py
@@ -1,11 +1,11 @@
-"""
-Bootstrap a node with step-ca root certificate.
+"""Bootstrap a node with step-ca root certificate.
 
 This Ansible module bootstraps a step-ca node by installing the root certificates
 and optionally installing the step-cli tool.
 """
 
 from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.matonb.step.plugins.module_utils.utils import (
     read_json_file,
 )
@@ -13,14 +13,9 @@ from ansible_collections.matonb.step.plugins.module_utils.utils import (
 
 def main():
     """Run the Ansible module."""
-    module_args = {
-        "config_file": {"type": "str", "required": True}
-    }
+    module_args = {"config_file": {"type": "str", "required": True}}
 
-    module = AnsibleModule(
-        argument_spec=module_args,
-        supports_check_mode=True
-    )
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
 
     config_file = module.params["config_file"]
     config_data, error = read_json_file(config_file)

--- a/plugins/modules/configure.py
+++ b/plugins/modules/configure.py
@@ -1,5 +1,4 @@
-"""
-Modify a step-ca configuration JSON file with provided updates.
+"""Modify a step-ca configuration JSON file with provided updates.
 
 This module takes a JSON file path and a dictionary of updates,
 modifies the JSON file, and saves the changes.
@@ -20,9 +19,9 @@ def load_json_file(json_path):
         return {}
 
     try:
-        with open(json_path, "r", encoding=ENCODING) as file:
+        with open(json_path, encoding=ENCODING) as file:
             return json.load(file)
-    except (json.JSONDecodeError, IOError) as error:
+    except (OSError, json.JSONDecodeError) as error:
         return {"error": f"Failed to load JSON file: {str(error)}"}
 
 
@@ -31,7 +30,7 @@ def save_json_file(json_path, data):
     try:
         with open(json_path, "w", encoding=ENCODING) as file:
             json.dump(data, file, indent=4)
-    except IOError as error:
+    except OSError as error:
         return {"error": f"Failed to write JSON file: {str(error)}"}
     return {"success": True}
 
@@ -39,41 +38,20 @@ def save_json_file(json_path, data):
 def main():
     """Run the Ansible module."""
     module_args = {
-        "ca_config": {
-            "type": "path", "required": False, "default": None
-        },
-        "ca_path": {
-            "type": "path", "required": False, "default": None
-        },
-        "crt": {
-            "type": "path", "required": False, "default": None
-        },
-        "db_datasource": {
-            "type": "str", "required": False, "default": None
-        },
-        "json_path": {
-            "type": "str", "required": True
-        },
-        "key": {
-            "type": "path", "required": False, "default": None
-        },
-        "root": {
-            "type": "path", "required": False, "default": None
-        },
+        "ca_config": {"type": "path", "required": False, "default": None},
+        "ca_path": {"type": "path", "required": False, "default": None},
+        "crt": {"type": "path", "required": False, "default": None},
+        "db_datasource": {"type": "str", "required": False, "default": None},
+        "json_path": {"type": "str", "required": True},
+        "key": {"type": "path", "required": False, "default": None},
+        "root": {"type": "path", "required": False, "default": None},
     }
 
-    module = AnsibleModule(
-        argument_spec=module_args,
-        supports_check_mode=True
-    )
+    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
 
     json_path = module.params["json_path"]
 
-    updates = {
-        key: module.params[key]
-        for key in module_args.keys()
-        if key != "json_path" and module.params[key] is not None
-    }
+    updates = {key: module.params[key] for key in module_args if key != "json_path" and module.params[key] is not None}
 
     json_data = load_json_file(json_path)
 
@@ -90,11 +68,7 @@ def main():
     if "error" in result:
         module.fail_json(msg=result["error"])
 
-    module.exit_json(
-        changed=True,
-        msg="JSON file updated",
-        new_data=json_data
-    )
+    module.exit_json(changed=True, msg="JSON file updated", new_data=json_data)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/provisioner.py
+++ b/plugins/modules/provisioner.py
@@ -1,16 +1,12 @@
-"""
-Manage step-ca provisioners.
+"""Manage step-ca provisioners.
 
 This Ansible module allows creating, removing, and querying provisioners
 in a step-ca certificate authority. It supports different provisioner
 types including JWK and ACME.
 """
 
-from __future__ import absolute_import, division, print_function
-
-__metaclass__ = type
-
 from ansible.module_utils.basic import AnsibleModule
+
 from ansible_collections.matonb.step.plugins.module_utils.provisioner import (
     ACMEProvisioner,
     JWKProvisioner,
@@ -263,11 +259,7 @@ def main() -> None:
 
         changed = False
         restart_required = False
-        matched = [
-            p
-            for p in provisioners
-            if p.name == name and (not provisioner_type or p.type == provisioner_type)
-        ]
+        matched = [p for p in provisioners if p.name == name and (not provisioner_type or p.type == provisioner_type)]
 
         # Store the password used (if generated)
         used_password = None
@@ -300,9 +292,7 @@ def main() -> None:
             elif provisioner_type == "ACME":
                 matched = [ACMEProvisioner(name=name, type=provisioner_type)]
             else:
-                module.fail_json(
-                    msg=f"Unsupported provisioner type: {provisioner_type}"
-                )
+                module.fail_json(msg=f"Unsupported provisioner type: {provisioner_type}")
         elif state == "present" and not provisioner_type:
             module.fail_json(
                 msg="Parameter 'type' is required when state is 'present' and the provisioner doesn't exist."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dynamic = ["version"]
 dev = [
     "pre-commit>=4.2.0",
     "ruff>=0.12.4",
+    "yamllint>=1.35.0",
+    "ansible-lint>=24.12.0",
+    "ansible-core>=2.15.0",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,154 @@
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "matonb.step"
+description = "Ansible collection for managing Smallstep Certificate Authority"
+authors = [{name = "Brett Maton", email = "brett@example.com"}]
+license = {text = "MIT"}
+requires-python = ">=3.9"
+dynamic = ["version"]
+
+[project.optional-dependencies]
+dev = [
+    "pre-commit>=4.2.0",
+    "ruff>=0.12.4",
+]
+
+[tool.ruff]
+line-length = 122  # Match your existing flake8 setting
+target-version = "py39"
+
+[tool.ruff.lint]
+select = [
+    "E",    # pycodestyle errors
+    "W",    # pycodestyle warnings
+    "F",    # pyflakes
+    "I",    # isort
+    "B",    # flake8-bugbear
+    "C4",   # flake8-comprehensions
+    "C90",  # mccabe complexity
+    "N",    # pep8-naming
+    "UP",   # pyupgrade
+    "YTT",  # flake8-2020
+    "ANN",  # flake8-annotations
+    "S",    # flake8-bandit (security)
+    "BLE",  # flake8-blind-except
+    "FBT",  # flake8-boolean-trap
+    "A",    # flake8-builtins
+    "COM",  # flake8-commas
+    "DTZ",  # flake8-datetimez
+    "EM",   # flake8-errmsg
+    "ISC",  # flake8-implicit-str-concat
+    "ICN",  # flake8-import-conventions
+    "G",    # flake8-logging-format
+    "INP",  # flake8-no-pep420
+    "PIE",  # flake8-pie
+    "T20",  # flake8-print
+    "PYI",  # flake8-pyi
+    "PT",   # flake8-pytest-style
+    "Q",    # flake8-quotes
+    "RSE",  # flake8-raise
+    "RET",  # flake8-return
+    "SLF",  # flake8-self
+    "SLOT", # flake8-slots
+    "SIM",  # flake8-simplify
+    "TID",  # flake8-tidy-imports
+    "TCH",  # flake8-type-checking
+    "INT",  # flake8-gettext
+    "ARG",  # flake8-unused-arguments
+    "PTH",  # flake8-use-pathlib
+    "PGH",  # pygrep-hooks
+    "PL",   # pylint (PLC, PLE, PLR, PLW)
+    "TRY",  # tryceratops
+    "FLY",  # flynt
+    "PERF", # perflint
+    "FURB", # refurb
+    "LOG",  # flake8-logging
+    "RUF",  # ruff-specific rules
+    "D",    # pydocstyle
+]
+ignore = [
+    # Formatter conflicts
+    "COM812", # Trailing comma missing (conflicts with formatter)
+    "ISC001", # Implicitly concatenated string literals (conflicts with formatter)
+
+    # Ansible module specific allowances
+    "T201",   # print found (for debug output in modules)
+    "S101",   # Use of assert
+    "S603",   # subprocess call - needed for Ansible modules
+    "S607",   # subprocess call with shell - sometimes needed
+
+    # Type annotations (can be enabled gradually)
+    "ANN",    # Skip all type annotations for now
+
+    # Complexity allowances for existing code
+    "PLR0913", # Too many arguments to function call
+
+    # Code style preferences
+    "TID252",  # Allow relative imports in packages
+    "FBT002",  # Allow boolean default arguments (common in CLI tools)
+
+    # Exception handling style
+    "TRY003",  # Allow long exception messages
+    "TRY300",  # Allow statements not in else blocks
+    "BLE001",  # Allow broad exception catching
+
+    # Performance patterns common in this codebase
+    "PERF203", # Allow try-except in loops
+    "PERF401", # Allow manual list building over comprehensions
+
+    # File I/O patterns
+    "PTH123",  # Allow open() instead of Path.open()
+
+    # Return patterns
+    "RET504",  # Allow assignment before return
+
+    # Boolean argument patterns
+    "FBT001",  # Allow boolean positional arguments
+
+    # Docstring allowances
+    "D100",    # missing docstring in public module
+    "D104",    # missing docstring in public package
+    "D105",    # missing docstring in magic method
+
+    # Ansible module specific patterns
+    "INP001",  # implicit namespace package (Ansible collection structure)
+    "EM101",   # string literal in exception (common in error messages)
+    "EM102",   # f-string in exception (common in error messages)
+    "PLW1509", # preexec_fn with subprocess (needed for user switching)
+    "PTH",     # pathlib usage (os.path is still common in system tools)
+    "RUF010",  # explicit str() conversion (prefer explicit over implicit)
+    "SIM105",  # contextlib.suppress (prefer explicit try/except for clarity)
+    "ARG002",  # unused argument (interface compliance in abstract methods)
+]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+
+[tool.ruff.lint.mccabe]
+max-complexity = 10
+
+[tool.ruff.lint.pylint]
+max-args = 8
+max-branches = 15
+max-returns = 8
+max-statements = 60
+
+[tool.ruff.lint.per-file-ignores]
+"plugins/modules/*.py" = [
+    "D103",  # missing docstring in public function (main functions)
+    "PLR0912", # Too many branches
+    "PLR0915", # Too many statements
+]
+"plugins/module_utils/*.py" = [
+    "D101",  # missing docstring in public class (some utility classes)
+]
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"  # Use Google-style docstrings
+
+[tool.ruff.lint.isort]
+known-first-party = ["ansible_collections.matonb.step"]


### PR DESCRIPTION
- Replace .flake8 with modern pyproject.toml ruff setup
- Add 40+ linting rule categories for enhanced code quality
- Modernize type annotations (Dict -> dict, List -> list, etc.)
- Rename CommandTimeout -> CommandTimeoutError for PEP 8 compliance
- Add pre-commit hooks for automated formatting and linting
- Apply consistent code formatting across all Python modules