### PR TITLE
fix(ca_server): escalate for step user and group creation

### DIFF
--- a/roles/ca_server/tasks/main.yml
+++ b/roles/ca_server/tasks/main.yml
@@ -1,9 +1,11 @@
 ---
 - name: Ensure step group
+  become: true
   ansible.builtin.user:
     name: step
     system: true
 - name: Ensure step user
+  become: true
   ansible.builtin.user:
     name: step
     group: step


### PR DESCRIPTION
The `Ensure step group` and `Ensure step user` tasks had no `become`, so on a non-root connection they failed with `useradd: Permission denied` while the role's other privileged tasks (package install, capability, systemd unit) already escalate. Adds `become: true` to both for consistent behaviour.