### PR TITLE
fix(release): use semantic-release v10 version command and config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
       - name: Install python-semantic-release
         run: |
           python -m pip install --upgrade pip
-          pip install python-semantic-release
+          pip install 'python-semantic-release>=10,<11'
 
       - name: Run semantic-release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          semantic-release publish
+          semantic-release version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,10 +155,8 @@ known-first-party = ["ansible_collections.matonb.step"]
 
 [tool.semantic_release]
 build_command = ""
-commit_version_number = true
 tag_format = "v{version}"
-upload_to_github_release = true
-version_variable = "galaxy.yml:version"
+version_variables = ["galaxy.yml:version"]
 
 [tool.semantic_release.changelog.default_templates]
 changelog_file = "CHANGELOG.md"


### PR DESCRIPTION
The Release workflow failed with `No tags found … couldn't identify latest version`. In PSR v10, `semantic-release publish` only uploads assets to an already-tagged release; `semantic-release version` is what creates the tag/changelog/commit/GitHub release (and bootstraps the first release on a tagless repo).

- `release.yml`: `semantic-release publish` → `semantic-release version`
- `pyproject.toml`: `version_variable` → `version_variables` (list); drop `commit_version_number` and `upload_to_github_release` (not v10 keys; no artifacts to upload).

Refs: [CLI commands](https://python-semantic-release.readthedocs.io/en/latest/api/commands.html), [Configuration](https://python-semantic-release.readthedocs.io/en/latest/configuration/configuration.html)