### PR TITLE
ci(lint): run ruff and yamllint through pre-commit

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,18 +23,17 @@ jobs:
       - name: Install linting tools
         run: |
           python -m pip install --upgrade pip
-          pip install ansible ansible-lint ruff yamllint
+          pip install ansible ansible-lint pre-commit
 
       - name: Lint Ansible roles
         run: |
           ansible-lint roles/
           ansible-lint plugins/
 
-      - name: Lint Python code
+      # ruff and yamllint run via pre-commit so CI uses exactly the versions
+      # pinned in .pre-commit-config.yaml - the same ones the local commit hook
+      # enforces. Installing them unpinned here let CI drift ahead of the hook,
+      # so upstream releases broke unrelated PRs on rules the gate never saw.
+      - name: Lint Python and YAML via pre-commit
         run: |
-          ruff check plugins/
-          ruff format --check plugins/
-
-      - name: Lint YAML files
-        run: |
-          yamllint .
+          pre-commit run --all-files --show-diff-on-failure

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.1
+    rev: v0.16.0
     hooks:
       - id: ruff-format
         name: ruff (formatter)
@@ -20,7 +20,7 @@ repos:
         pass_filenames: false
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.35.1
+    rev: v1.38.0
     hooks:
       - id: yamllint
         name: yamllint


### PR DESCRIPTION
Stacked on #28 — merge that first, GitHub will retarget this to `main`.

## Problem

The lint workflow installed ruff **unpinned** (`pip install ... ruff yamllint`) while `.pre-commit-config.yaml` pinned **ruff v0.12.1**. The local commit gate therefore ran a linter roughly a year behind CI, and the gap widened with every upstream release.

Ruff **0.16.0** (released 2026-07-23) stabilised `PLR0917` and began formatting Python code blocks inside Markdown. `main` last went green 2026-06-16, so the next PR opened after that release — #28 — failed CI twice on rules the local hook could not see, in files the PR never touched. Verified directly: `pre-commit run --all-files` passed clean at v0.12.1 on exactly the tree CI rejected.

A gate that cannot fail where CI fails is not a gate.

## Change

- CI runs `pre-commit run --all-files --show-diff-on-failure` instead of its own ruff/yamllint invocations, so the pinned revs in `.pre-commit-config.yaml` are the single source of truth and `pre-commit autoupdate` becomes the deliberate, reviewable way to move them.
- Revs bumped to what CI had already been installing unpinned: ruff `v0.12.1` → `v0.16.0`, yamllint `v1.35.1` → `v1.38.0`. (Without the yamllint bump this change would have silently *downgraded* CI from 1.38.0.)
- `ansible-lint` stays a separate step — it is commented out of the hook config.

Also note `.git/hooks/pre-commit` was not installed in at least one working clone, so the gate was not running locally at all. `pre-commit install` fixes that per-clone and is not something a repo change can enforce.

## Verification

`pre-commit run --all-files` on this branch, with the new pins:

```
ruff (formatter).........................................................Passed
ruff (linter autofix)....................................................Passed
ruff (config validation).................................................Passed
yamllint.................................................................Passed
```