### PR TITLE
fix(provisioner): read provisioners from ca.json in config mode

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,7 @@ jobs:
         run: |
           ansible-lint roles/
           ansible-lint plugins/
+          ansible-lint examples/
 
       # ruff and yamllint run via pre-commit so CI uses exactly the versions
       # pinned in .pre-commit-config.yaml - the same ones the local commit hook

--- a/README.md
+++ b/README.md
@@ -69,9 +69,11 @@ Modify Step CA configuration JSON file (ca.json). Supports top-level parameters 
 Creates, updates and removes provisioners. Works against both management modes —
 see [Management modes](#management-modes) below.
 
-> **The CA must be running.** `step ca provisioner list` reads the CA's
-> `/provisioners` HTTP endpoint, so this module needs a reachable, running
-> step-ca in *both* modes, not just admin mode.
+> **Admin mode needs a running CA; config mode does not.** In admin mode every
+> operation goes through the CA, so it must be reachable. In config mode the
+> module reads and writes `ca.json` directly, so provisioners can be configured
+> before step-ca is ever started — but `ca_path` or `ca_config` must be set so
+> the file can be found.
 
 ### Parameters
 
@@ -82,8 +84,8 @@ see [Management modes](#management-modes) below.
 | `admin_password_file` | path    | no       |           | File holding the password that decrypts `admin_provisioner`'s key. Required in admin mode               |
 | `admin_provisioner`   | string  | no       |           | Provisioner used to mint admin credentials. Required in admin mode                                      |
 | `admin_subject`       | string  | no       |           | Subject of the CA administrator (`step` by default). Required in admin mode                             |
-| `ca_config`           | path    | no       |           | Path to `ca.json`. Defaults to `config/ca.json` under `ca_path`                                         |
-| `ca_path`             | path    | no       |           | Optional path to the step CA configuration directory (sets STEPPATH)                                    |
+| `ca_config`           | path    | no\*     |           | Path to `ca.json`. Defaults to `config/ca.json` under `ca_path`                                         |
+| `ca_path`             | path    | no\*     |           | Path to the step CA configuration directory (sets STEPPATH)                                             |
 | `ca_url`              | string  | no       |           | Optional URL of the step CA. Falls back to the CA's `defaults.json`                                     |
 | `context`             | string  | no       |           | Optional step context name to operate in                                                                |
 | `debug`               | boolean | no       | `false`   | If true, prints CLI commands to stderr before execution                                                 |
@@ -98,6 +100,10 @@ see [Management modes](#management-modes) below.
 | `x509_default`        | string  | no       |           | Default certificate duration for X509 certificates                                                      |
 | `x509_max`            | string  | no       |           | Maximum certificate duration for X509 certificates                                                      |
 | `x509_min`            | string  | no       |           | Minimum certificate duration for X509 certificates                                                      |
+
+\* One of `ca_path` or `ca_config` is required, unless `management_mode` is set
+to `admin`. They locate `ca.json`, which is both how the management mode is
+detected and, in config mode, where the existing provisioners are read from.
 
 The `x509_*` options have no default. A claim that is left unset is inherited
 from the CA's own defaults and is not reconciled; a claim that is set is kept at
@@ -115,7 +121,10 @@ by probing the CA rather than by taking a flag.
 
 A CA is in admin mode when it was initialised with `remote_management: true`,
 which sets `authority.enableAdmin` in `ca.json`. With `management_mode: auto`
-(the default) the module reads that setting and follows it.
+(the default) the module reads that setting and follows it — the same field
+step-ca itself reads, so this detects the mode rather than inferring it. If
+`ca.json` cannot be found or read, the mode is genuinely unknown and the task
+fails rather than picking one; set `management_mode` explicitly in that case.
 
 Admin API changes take effect immediately, so `restart_required` is `false` in
 admin mode. In config mode the file is edited in place and step-ca must be
@@ -186,6 +195,27 @@ Three behaviours changed for existing config-mode users:
 callback logs. Set `no_log: true` on the task, or supply `password` yourself, if
 that matters to you.
 
+### Upgrading from 1.1.x
+
+**`ca_path` or `ca_config` is now required, unless you set
+`management_mode: admin`.** Two things that used to work by reaching the CA over
+HTTP now need `ca.json`: detecting the management mode, and reading the existing
+provisioners in config mode. A task that set neither previously carried on with
+a warning and an assumed mode; it now fails with a message naming both remedies.
+So does a task whose `ca_path` does not actually contain `config/ca.json` — the
+containerised case, where `defaults.json` points `ca-config` somewhere else — or
+whose `ca.json` the module cannot read because it runs without `become`.
+
+This closes a real bug ([#31](https://github.com/matonb/step/issues/31)): in
+config mode the module read provisioners from the CA's *loaded* configuration
+while writing them to `ca.json`, so re-running a play before step-ca had been
+reloaded failed with `provisioner with name acme already exists`. Reading the
+file it writes makes a single run converge — and means config-mode tasks no
+longer need the CA to be running at all.
+
+Add `ca_path: /etc/step-ca` to affected tasks, or `management_mode: admin` if
+the CA is reached only by `ca_url`.
+
 ### Deprecations
 
 | Option        | Status                                                                                             |
@@ -246,18 +276,21 @@ X509 duration parameters accept time units as follows:
 
 ## Examples
 
+Complete, runnable playbooks live in [`examples/`](examples/).
+
 ### Create a new JWK provisioner
 
 ```yaml
 - name: Create JWK provisioner
   matonb.step.provisioner:
+    ca_path: /etc/step-ca
     name: my-jwk-provisioner
-    type: JWK
-    state: present
     run_as: step # Run as step user for proper CA access
-    x509_min_dur: 30m
-    x509_max_dur: 48h
-    x509_default_dur: 24h
+    state: present
+    type: JWK
+    x509_default: 24h
+    x509_max: 48h
+    x509_min: 30m
   become: true # Required when using run_as
   register: provisioner_result
 
@@ -268,15 +301,19 @@ X509 duration parameters accept time units as follows:
   become: true
   when: provisioner_result.restart_required | bool
 ```
+
+Prefer `notify:` and a handler over a `when:` guard on every task — a play that
+adds several provisioners then reloads once, at the end.
 
 ### Remove a provisioner
 
 ```yaml
 - name: Remove provisioner
   matonb.step.provisioner:
+    ca_path: /etc/step-ca
     name: old-provisioner
-    state: absent
     run_as: step
+    state: absent
   become: true # Required when using run_as
   register: provisioner_result
 
@@ -288,42 +325,38 @@ X509 duration parameters accept time units as follows:
   when: provisioner_result.restart_required | bool
 ```
 
-### Check if a provisioner exists
+`state: absent` works for provisioners of any type, including ones this module
+cannot create.
+
+### Check whether a provisioner exists
+
+There is no read-only mode: `state: present` needs `type` so it knows what to
+create if the provisioner is missing. Use check mode, which predicts the change
+without making it — `changed` is `false` when the provisioner already matches.
 
 ```yaml
-- name: Check if provisioner exists
+- name: Check whether the provisioner exists
   matonb.step.provisioner:
+    ca_path: /etc/step-ca
     name: my-provisioner
     run_as: step
+    type: JWK
   become: true # Required when using run_as
+  check_mode: true
   register: provisioner_check
 
 - name: Display result
   ansible.builtin.debug:
-    msg: "Provisioner {{ 'exists' if provisioner_check.provisioners else 'does not exist' }}"
+    msg: "Provisioner {{ 'is missing' if provisioner_check.changed else 'exists' }}"
 ```
 
-### Specifying an alternate path
+`provisioner_check.provisioners` carries the matching provisioner's full
+configuration when one was found.
 
-```yaml
-- name: Create provisioner with specific CA path
-  matonb.step.provisioner:
-    name: new-provisioner
-    type: JWK
-    run_as: step
-    ca_path: /etc/step-ca
-    x509_min_dur: 15m
-    x509_max_dur: 96h
-  become: true # Required when using run_as
-  register: provisioner_result
-
-- name: Restart step-ca service if needed
-  ansible.builtin.service:
-    name: step-ca
-    state: restarted
-  become: true
-  when: provisioner_result.restart_required | bool
-```
+`type` also narrows the match, so this asks whether a **JWK** named
+`my-provisioner` exists. A provisioner of that name but another type reports as
+missing — and a non-check run of the same task would then try to create it, which
+step refuses.
 
 ## Special Notes
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,42 @@
+# Examples
+
+Example playbooks for `matonb.step`. They are written to be read, not run
+unmodified: every one targets a `step_ca` inventory group and assumes the CA
+lives at `/etc/step-ca` owned by the `step` user. Change the `vars` block to
+match your deployment.
+
+| Playbook | Shows |
+| --- | --- |
+| [`provisioner_config_mode.yml`](provisioner_config_mode.yml) | The default CA, which keeps provisioners in `ca.json`. Adding, removing, capturing a generated password, and the `notify` handler that `restart_required` exists to drive. |
+| [`provisioner_admin_mode.yml`](provisioner_admin_mode.yml) | A CA initialised with `--remote-management`. Both credential forms, and why changes need no reload. |
+| [`provisioner_reconcile.yml`](provisioner_reconcile.yml) | Declaring `x509_*` durations once and letting re-runs put them back if they drift. |
+
+## Which mode am I in?
+
+If the CA was created with `step ca init --remote-management`, it is in admin
+mode. Otherwise it is in config mode. You can confirm from the CA itself:
+
+```console
+$ jq .authority.enableAdmin /etc/step-ca/config/ca.json
+true
+```
+
+The module detects this for you and reports what it used as
+`management_mode`. Set `management_mode: admin` or `config` explicitly if you
+want a task to fail rather than quietly do the other thing.
+
+## The one thing worth knowing up front
+
+In config mode the module edits `ca.json`, and step-ca only picks that up when
+it is reloaded. `restart_required: true` is telling you to do something about
+it — pair changing tasks with a handler, as the examples do. In admin mode
+changes go through the Admin API and are live immediately, so
+`restart_required` is always `false`.
+
+Running these needs the collection installed, or a checkout reachable under an
+`ansible_collections/matonb/step` path:
+
+```console
+$ ansible-galaxy collection install matonb.step
+$ ansible-playbook -i inventory.ini examples/provisioner_config_mode.yml
+```

--- a/examples/provisioner_admin_mode.yml
+++ b/examples/provisioner_admin_mode.yml
@@ -1,0 +1,62 @@
+---
+# Managing provisioners on a CA initialised with --remote-management.
+#
+# Provisioners live in the CA database, not ca.json, and are changed through
+# the authenticated Admin API. Changes are live immediately, so
+# restart_required is always false and no handler is needed - but the CA has to
+# be running and reachable, and credentials are mandatory.
+#
+# The step CLI prompts for any admin input it is not given, which an Ansible
+# task experiences as a hang rather than a failure. The module rejects
+# incomplete credentials before invoking step, so an error here means something
+# is missing rather than wrong.
+- name: Manage provisioners on a remote-management step-ca
+  hosts: step_ca
+  become: true
+  gather_facts: false
+
+  vars:
+    step_ca_path: /etc/step-ca
+    step_ca_url: https://ca.example.com
+    step_ca_user: step
+
+  tasks:
+    # Credentials minted just in time: the CLI signs a short-lived certificate
+    # for admin_subject using admin_provisioner. This is what
+    # `step ca init --remote-management` sets up.
+    - name: Add an ACME provisioner
+      matonb.step.provisioner:
+        admin_password_file: /etc/step-ca/secrets/provisioner_password
+        admin_provisioner: admin
+        admin_subject: step
+        ca_path: "{{ step_ca_path }}"
+        ca_url: "{{ step_ca_url }}"
+        name: acme
+        run_as: "{{ step_ca_user }}"
+        type: ACME
+      register: acme_provisioner
+
+    - name: Admin API changes need no reload
+      ansible.builtin.assert:
+        that:
+          - acme_provisioner.management_mode == 'admin'
+          - not acme_provisioner.restart_required
+        fail_msg: >-
+          Expected the Admin API to be used. If step fell back to editing
+          ca.json, check that step-ca is running, reachable, and was restarted
+          since remote management was enabled.
+
+    # The alternative to just-in-time credentials: present an admin certificate
+    # and key you already hold. The key must not be encrypted - step loads it
+    # without a password option and would prompt.
+    - name: Add a JWK provisioner using an existing admin certificate
+      matonb.step.provisioner:
+        admin_cert: /etc/step-ca/admin/admin.crt
+        admin_key: /etc/step-ca/admin/admin.key
+        ca_path: "{{ step_ca_path }}"
+        ca_url: "{{ step_ca_url }}"
+        name: cicd
+        run_as: "{{ step_ca_user }}"
+        type: JWK
+        x509_default: 720h
+        x509_max: 17520h

--- a/examples/provisioner_config_mode.yml
+++ b/examples/provisioner_config_mode.yml
@@ -1,0 +1,61 @@
+---
+# Managing provisioners on a CA that keeps them in ca.json.
+#
+# This is the default: any CA not initialised with --remote-management. The
+# module edits ca.json in place, so step-ca has to reload before the change is
+# live. That is what restart_required reports, and why every changing task
+# notifies a handler rather than reloading inline - a play adding three
+# provisioners then reloads once, at the end.
+- name: Manage provisioners on a ca.json-managed step-ca
+  hosts: step_ca
+  become: true
+  gather_facts: false
+
+  vars:
+    step_ca_path: /etc/step-ca
+    step_ca_user: step
+
+  handlers:
+    - name: Reload step-ca
+      ansible.builtin.systemd_service:
+        name: step-ca
+        state: reloaded
+
+  tasks:
+    - name: Add an ACME provisioner
+      matonb.step.provisioner:
+        ca_path: "{{ step_ca_path }}"
+        name: acme
+        run_as: "{{ step_ca_user }}"
+        type: ACME
+      notify: Reload step-ca
+
+    - name: Add a JWK provisioner for CI
+      matonb.step.provisioner:
+        ca_path: "{{ step_ca_path }}"
+        name: cicd
+        run_as: "{{ step_ca_user }}"
+        type: JWK
+        x509_default: 720h
+        x509_max: 17520h
+        x509_min: 5m
+      notify: Reload step-ca
+      register: cicd_provisioner
+
+    # The password is only returned on the run that created the key, and only
+    # when the module generated it. Store it somewhere before it is lost - pass
+    # `password` yourself if you would rather supply your own.
+    - name: Report the generated provisioner password
+      ansible.builtin.debug:
+        msg: >-
+          Generated password for cicd:
+          {{ cicd_provisioner.generated_password }}
+      when: cicd_provisioner.generated_password is defined
+
+    - name: Retire an old provisioner
+      matonb.step.provisioner:
+        ca_path: "{{ step_ca_path }}"
+        name: legacy
+        run_as: "{{ step_ca_user }}"
+        state: absent
+      notify: Reload step-ca

--- a/examples/provisioner_reconcile.yml
+++ b/examples/provisioner_reconcile.yml
@@ -1,0 +1,74 @@
+---
+# Declaring certificate durations and letting re-runs converge (issue #21).
+#
+# The claims a task sets are reconciled on every run: if someone widens
+# x509_max by hand, the next run puts it back and names what it changed in the
+# `updated` return value. Claims the task does not set are left alone, so this
+# does not fight whatever else is configured on the provisioner.
+#
+# Durations are compared numerically, not textually. The CA normalises what it
+# stores - 5m comes back as 5m0s - and that is not treated as drift.
+- name: Keep provisioner certificate durations at their declared values
+  hosts: step_ca
+  become: true
+  gather_facts: false
+
+  vars:
+    step_ca_path: /etc/step-ca
+    step_ca_user: step
+
+    # One place to change a TTL policy, applied to every provisioner listed.
+    step_provisioners:
+      - name: cicd
+        type: JWK
+      - name: acme
+        type: ACME
+
+  handlers:
+    - name: Reload step-ca
+      ansible.builtin.systemd_service:
+        name: step-ca
+        state: reloaded
+
+  tasks:
+    - name: Apply the certificate duration policy
+      matonb.step.provisioner:
+        ca_path: "{{ step_ca_path }}"
+        name: "{{ item.name }}"
+        run_as: "{{ step_ca_user }}"
+        type: "{{ item.type }}"
+        x509_default: 720h    # 30 days
+        x509_max: 17520h      # 2 years
+        x509_min: 5m
+      loop: "{{ step_provisioners }}"
+      loop_control:
+        label: "{{ item.name }}"
+      notify: Reload step-ca
+      register: policy
+
+    - name: Show which claims were reconciled
+      ansible.builtin.debug:
+        msg: "{{ item.item.name }}: {{ item.updated | join(', ') }}"
+      loop: "{{ policy.results }}"
+      loop_control:
+        label: "{{ item.item.name }}"
+      when: item.updated is defined
+
+    # Nothing above needs the CA to be running: in this mode the module reads
+    # ca.json, the same file it writes. A second run before the reload is
+    # correctly a no-op.
+    - name: Confirm a repeat run changes nothing
+      matonb.step.provisioner:
+        ca_path: "{{ step_ca_path }}"
+        name: "{{ step_provisioners[0].name }}"
+        run_as: "{{ step_ca_user }}"
+        x509_default: 720h
+        x509_max: 17520h
+        x509_min: 5m
+      check_mode: true
+      register: repeat
+
+    - name: The policy has converged
+      ansible.builtin.assert:
+        that: repeat is not changed
+        fail_msg: "Expected the declared durations to already be in place"

--- a/plugins/module_utils/connection.py
+++ b/plugins/module_utils/connection.py
@@ -26,7 +26,7 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum
 from subprocess import CompletedProcess
-from typing import Optional
+from typing import Any, Optional
 
 from .process import run_command
 from .utils import read_json_file
@@ -246,6 +246,55 @@ class StepConnection:
         )
 
 
+def read_authority(config: Any, config_file: str) -> tuple[dict, Optional[str]]:
+    """Extract the C(authority) block from a parsed C(ca.json).
+
+    A file with no C(authority) block reads as empty; a file whose shape is
+    wrong is an error. Keeping those apart matters, because "nothing is
+    configured" and "this is not the file you think it is" would otherwise look
+    identical to a caller - and the first would silently reconfigure the CA.
+
+    Args:
+        config: Whatever :func:`read_json_file` returned for C(config_file).
+        config_file: The path, used only to build the error message.
+
+    Returns:
+        Tuple of the authority block (empty if absent) and an error (or None).
+    """
+    if not isinstance(config, dict):
+        return {}, f"'{config_file}' does not hold a JSON object"
+
+    authority = config.get("authority") or {}
+    if not isinstance(authority, dict):
+        return {}, f"the 'authority' entry in '{config_file}' is not a JSON object"
+
+    return authority, None
+
+
+def read_provisioners(config: Any, config_file: str) -> tuple[list, Optional[str]]:
+    """Extract C(authority.provisioners) from a parsed C(ca.json).
+
+    Args:
+        config: Whatever :func:`read_json_file` returned for C(config_file).
+        config_file: The path, used only to build the error message.
+
+    Returns:
+        Tuple of the provisioner entries (empty if absent) and an error
+        (or None).
+    """
+    authority, error = read_authority(config, config_file)
+    if error:
+        return [], error
+
+    provisioners = authority.get("provisioners") or []
+    if not isinstance(provisioners, list):
+        return [], f"the 'authority.provisioners' entry in '{config_file}' is not a list"
+    if not all(isinstance(item, dict) for item in provisioners):
+        return [], f"'authority.provisioners' in '{config_file}' holds an entry that is not a JSON object"
+
+    return provisioners, None
+
+
 def configured_mode(connection: StepConnection) -> tuple[Optional[ManagementMode], Optional[str]]:
     """Determine the management mode from the CA's own configuration.
 
@@ -260,14 +309,17 @@ def configured_mode(connection: StepConnection) -> tuple[Optional[ManagementMode
     """
     config_file = connection.config_file()
     if not config_file:
-        return None, "Cannot determine the management mode without 'ca_path' or 'ca_config'."
+        return None, "neither 'ca_path' nor 'ca_config' is set, so ca.json cannot be located"
 
     config, error = read_json_file(config_file)
     if error:
         return None, error
 
-    enabled = config.get("authority", {}).get("enableAdmin", False)
-    return (ManagementMode.ADMIN if enabled else ManagementMode.CONFIG), None
+    authority, error = read_authority(config, config_file)
+    if error:
+        return None, error
+
+    return (ManagementMode.ADMIN if authority.get("enableAdmin", False) else ManagementMode.CONFIG), None
 
 
 def observed_mode(result: CompletedProcess) -> ManagementMode:

--- a/plugins/module_utils/provisioner.py
+++ b/plugins/module_utils/provisioner.py
@@ -11,9 +11,10 @@ This module defines:
   drift detection alike.
 - :class:`StepProvisionerClient`, which turns those into step CLI invocations.
 
-The client is deliberately unaware of which management mode the CA is in: the
-commands are identical either way, and the connection supplies any admin
-credentials. See :mod:`connection` for the mode handling.
+Writing is identical in both management modes: the commands are the same and the
+connection supplies any admin credentials. Reading is not, and :meth:`list`
+takes the mode for that reason - see its docstring. Everything else here is
+mode-agnostic; see :mod:`connection` for the mode handling itself.
 """
 
 import json
@@ -23,8 +24,8 @@ from dataclasses import dataclass, field
 from subprocess import CompletedProcess
 from typing import Optional
 
-from .connection import StepConnection
-from .utils import generate_secure_password, parse_duration, write_secret_file
+from .connection import ManagementMode, StepConnection, read_provisioners
+from .utils import generate_secure_password, parse_duration, read_json_file, write_secret_file
 
 # Seconds to allow a step command before assuming it is waiting on input that
 # will never arrive. Minting an admin credential involves a round trip to the
@@ -288,12 +289,11 @@ class StepProvisionerClient:
 
     connection: StepConnection
 
-    def list(self) -> list[Provisioner]:
-        """Load the CA's current provisioners.
-
-        C(step ca provisioner list) reads the CA's public provisioners
-        endpoint, so it needs no admin credentials and behaves the same in
-        both management modes.
+    # The two readers are defined before list(), which shadows the built-in
+    # `list` for the remainder of the class body: a `list[Provisioner]`
+    # annotation below it would be evaluated against the method, not the type.
+    def _list_from_ca(self) -> list[Provisioner]:
+        """Read the provisioners the running CA reports.
 
         Returns:
             List[Provisioner]: Every provisioner the CA reports.
@@ -310,6 +310,66 @@ class StepProvisionerClient:
             raise RuntimeError("Failed to parse JSON from step output.") from err
 
         return [build_provisioner(item) for item in raw_data]
+
+    def _list_from_config(self) -> list[Provisioner]:
+        """Read the provisioners recorded in the CA's C(ca.json).
+
+        An unreadable file is an error rather than a fall back to the CA:
+        falling back would silently reintroduce the read/write split this
+        exists to close.
+
+        Returns:
+            List[Provisioner]: Every provisioner in C(authority.provisioners).
+
+        Raises:
+            RuntimeError: If C(ca.json) cannot be located, read or understood.
+        """
+        config_file = self.connection.config_file()
+        if not config_file:
+            raise RuntimeError(
+                "Cannot read provisioners in config mode without knowing where ca.json is. "
+                "Set 'ca_path' or 'ca_config' to name the file directly. If this CA is actually "
+                "in admin mode, set 'management_mode' to 'admin' and neither is needed."
+            )
+
+        config, error = read_json_file(config_file)
+        if error:
+            raise RuntimeError(f"Cannot read provisioners from '{config_file}': {error}")
+
+        entries, error = read_provisioners(config, config_file)
+        if error:
+            raise RuntimeError(f"Cannot read provisioners: {error}.")
+
+        return [build_provisioner(item) for item in entries]
+
+    def list(self, mode: ManagementMode) -> list[Provisioner]:
+        """Load the current provisioners from wherever this mode stores them.
+
+        The read has to come from the same place the write goes, or the two
+        disagree and the module never converges:
+
+        - **Admin mode** keeps provisioners in the CA database and changes them
+          through the Admin API, so the CA is the source of truth and
+          C(step ca provisioner list) reads it.
+        - **Config mode** edits C(ca.json), which the CA only picks up on SIGHUP.
+          Reading the CA there would report its *loaded* configuration, so a
+          re-run before the reload would not see a provisioner that had just
+          been written and would try to create it again.
+
+        Reading the file also means config-mode tasks need no running CA.
+
+        Args:
+            mode: The resolved management mode.
+
+        Returns:
+            List[Provisioner]: Every provisioner in the relevant source.
+
+        Raises:
+            RuntimeError: If the source cannot be read or parsed.
+        """
+        if mode is ManagementMode.CONFIG:
+            return self._list_from_config()
+        return self._list_from_ca()
 
     def add(
         self,

--- a/plugins/modules/provisioner.py
+++ b/plugins/modules/provisioner.py
@@ -23,6 +23,12 @@ description:
     other CA keeps its provisioners in C(ca.json), which is edited in place and
     requires the service to be restarted or sent SIGHUP.
   - >-
+    In config mode the existing provisioners are read from C(ca.json) rather
+    than from the CA, because that is the file being edited. This makes a task
+    idempotent before the service has reloaded, and means it does not need the
+    CA to be running, but it does require I(ca_path) or I(ca_config) so the file
+    can be found.
+  - >-
     Supports check mode. Under C(--check) the provisioner list is read and the
     resulting C(changed)/C(restart_required) values are predicted, but no
     provisioner is added, updated or removed and no password is generated.
@@ -70,6 +76,10 @@ options:
     description:
       - Path to the CA configuration file. Defaults to C(ca.json) under I(ca_path).
       - Also used to detect the management mode when I(management_mode) is C(auto).
+      - >-
+        Required unless I(ca_path) is set, or I(management_mode) is set to
+        C(admin). It is how C(ca.json) is located, both to detect the management
+        mode and to read the existing provisioners in config mode.
     required: false
     type: path
     version_added: "1.1.0"
@@ -77,6 +87,10 @@ options:
     description:
       - Optional path to the step CA configuration directory.
       - Sets the STEPPATH environment variable before executing step commands.
+      - >-
+        Required unless I(ca_config) is set, or I(management_mode) is set to
+        C(admin). It is how C(ca.json) is located, both to detect the management
+        mode and to read the existing provisioners in config mode.
     required: false
     type: path
   ca_url:
@@ -111,7 +125,9 @@ options:
     description:
       - Which management mode this task expects the CA to be in.
       - >-
-        C(auto) reads C(authority.enableAdmin) from the CA configuration.
+        C(auto) reads C(authority.enableAdmin) from the CA configuration, the
+        same field step-ca itself reads. It needs I(ca_path) or I(ca_config) to
+        find that file, and fails rather than picking a mode when it cannot.
         C(admin) and C(config) assert a mode rather than force one.
       - >-
         The step CLI always chooses the path itself, based on what the CA
@@ -430,6 +446,12 @@ def build_credentials(module: AnsibleModule) -> AdminCredentials:
 def resolve_mode(module: AnsibleModule, connection: StepConnection) -> ManagementMode:
     """Decide which management mode to use.
 
+    C(auto) reads C(authority.enableAdmin), the same field step-ca itself reads,
+    so it detects the mode rather than inferring it. When that field cannot be
+    reached the mode is genuinely unknown, and the task fails instead of picking
+    one: guessing C(config) against an admin-mode CA sends reads to the wrong
+    source and writes to a file the CA will never load.
+
     Args:
         module: The Ansible module instance.
         connection: The connection identifying the CA.
@@ -443,8 +465,13 @@ def resolve_mode(module: AnsibleModule, connection: StepConnection) -> Managemen
 
     mode, error = configured_mode(connection)
     if mode is None:
-        module.warn(f"Assuming '{ManagementMode.CONFIG.value}' management mode: {error}")
-        return ManagementMode.CONFIG
+        module.fail_json(
+            msg=(
+                f"Cannot determine the management mode: {error.rstrip('.')}. Either set 'ca_path' or 'ca_config' so "
+                "the CA configuration can be read, or set 'management_mode' to 'admin' or 'config' to "
+                "state it outright."
+            )
+        )
 
     return mode
 
@@ -627,14 +654,16 @@ def main() -> None:
             connection = replace(connection, admin=credentials)
 
         client = StepProvisionerClient(connection)
-        matched = match_provisioners(client.list(), name, provisioner_type)
+        matched = match_provisioners(client.list(mode), name, provisioner_type)
 
         apply = apply_absent if state == "absent" else apply_present
         fragment, effective_mode = apply(module, client, mode, matched)
 
-        # Report the state after the change rather than before it.
+        # Report the state after the change rather than before it, reading back
+        # from wherever step actually wrote: on a mode mismatch that is not the
+        # source the first read came from.
         if fragment["changed"] and not module.check_mode:
-            matched = match_provisioners(client.list(), name, provisioner_type)
+            matched = match_provisioners(client.list(effective_mode), name, provisioner_type)
 
         result = {
             "management_mode": effective_mode.value,

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -39,7 +39,15 @@ CA loaded. That is what makes `restart_required` observable rather than merely
 asserted: the test checks the change is in `ca.json`, is **not** yet visible
 from the CA, and becomes visible after `SIGHUP`.
 
-## Two things worth knowing
+Every task runs **without reloading first**, which is the point. Add, re-add,
+reconcile a claim and remove all happen against a CA whose loaded configuration
+is stale, proving the module compares against `ca.json` — the file it writes —
+rather than against the CA. This is the regression test for
+[#31](https://github.com/matonb/step/issues/31); before the fix the second add
+failed with `provisioner with name acme already exists`. A single `SIGHUP` at
+the end confirms the CA converges on exactly what `ca.json` holds.
+
+## One thing worth knowing
 
 **`ca_config` has to be explicit against a containerised CA.** The container
 writes container-absolute paths into `config/defaults.json`:
@@ -51,10 +59,3 @@ writes container-absolute paths into `config/defaults.json`:
 The step CLI loads that file as its flag defaults, so a host-side run resolves
 paths that do not exist. This affects anyone managing a containerised CA from
 outside the container, not just these tests.
-
-**In config mode, `list` and `add` read different sources.** `list` queries the
-CA's *loaded* configuration over HTTP, while `add`/`remove` edit `ca.json`. Until
-step-ca reloads, the two disagree, so re-running a play before the reload will
-try to add a provisioner that is already in the file. This is why the module
-reports `restart_required`, and why real plays pair these tasks with
-`notify: restart step-ca`. The suite reloads after each change to mirror that.

--- a/tests/integration/config_mode.yml
+++ b/tests/integration/config_mode.yml
@@ -4,11 +4,11 @@
 # edits the same file the running CA loaded, which is what makes the
 # restart_required contract observable.
 #
-# Note the reload after every change. In config mode `add`/`remove` edit
-# ca.json while `list` reads the CA's *loaded* configuration over HTTP, so the
-# two disagree until step-ca is reloaded. That is why the module reports
-# restart_required, and why a real play pairs these tasks with
-# `notify: restart step-ca`.
+# Every task here runs WITHOUT reloading the CA first. That is the point: in
+# config mode `add`/`update`/`remove` edit ca.json, so the module must read
+# ca.json too, or it compares against the CA's stale loaded configuration and
+# fails to converge (issue #31). The single reload at the end proves
+# restart_required still means what it says.
 - name: Config mode (ca.json)
   hosts: localhost
   connection: local
@@ -59,6 +59,17 @@
           - acme_add.restart_required
         fail_msg: "Config mode add/check-mode/restart_required incorrect"
 
+    # Issue #31. The CA has not been reloaded, so its loaded configuration still
+    # has no provisioners. A module that reads the CA rather than ca.json sees
+    # nothing, tries to create acme a second time, and step refuses with
+    # "provisioner with name acme already exists" - failing this task.
+    - name: Re-add immediately, without reloading the CA
+      matonb.step.provisioner:
+        name: acme
+        type: ACME
+      args: "{{ connection_options }}"
+      register: acme_again
+
     - name: The provisioner landed in ca.json, not the database
       ansible.builtin.command: "grep -c acme {{ ca_dir }}/config/ca.json"
       register: after_grep
@@ -70,42 +81,17 @@
         url: "{{ ca_url }}/provisioners"
       register: before_reload
 
-    - name: Assert ca.json was edited and the change is not yet live
+    - name: Assert idempotence against ca.json while the CA is still stale
       ansible.builtin.assert:
         that:
+          - acme_again is not changed
           - after_grep.stdout | int > 0
           - >-
             'acme' not in
             (before_reload.json.provisioners | map(attribute='name') | list)
         fail_msg: >-
-          Expected ca.json to be edited and the running CA to be unaware
-
-    - name: Reload the CA, which is what restart_required is telling you to do
-      ansible.builtin.command: "docker kill -s HUP {{ container }}"
-      changed_when: true
-
-    - name: Wait for the reload
-      ansible.builtin.uri:
-        ca_path: "{{ ca_dir }}/certs/root_ca.crt"
-        url: "{{ ca_url }}/provisioners"
-      register: after_reload
-      until: >-
-        'acme' in
-        (after_reload.json.provisioners | map(attribute='name') | list)
-      retries: 15
-      delay: 2
-
-    - name: Add it again, now that the CA agrees with the file
-      matonb.step.provisioner:
-        name: acme
-        type: ACME
-      args: "{{ connection_options }}"
-      register: acme_again
-
-    - name: Assert idempotence
-      ansible.builtin.assert:
-        that: acme_again is not changed
-        fail_msg: "Re-adding an existing provisioner should be a no-op"
+          Expected a re-run to be a no-op against ca.json while the running CA
+          is still unaware of the change
 
     - name: Add a JWK provisioner with a claim
       matonb.step.provisioner:
@@ -115,22 +101,7 @@
       args: "{{ connection_options }}"
       register: jwk_add
 
-    - name: Reload so the CA reports it
-      ansible.builtin.command: "docker kill -s HUP {{ container }}"
-      changed_when: true
-
-    - name: Wait for the reload
-      ansible.builtin.uri:
-        ca_path: "{{ ca_dir }}/certs/root_ca.crt"
-        url: "{{ ca_url }}/provisioners"
-      register: with_jwk
-      until: >-
-        'cicd' in
-        (with_jwk.json.provisioners | map(attribute='name') | list)
-      retries: 15
-      delay: 2
-
-    - name: Re-run with the same claim
+    - name: Re-run with the same claim, still without a reload
       matonb.step.provisioner:
         name: cicd
         type: JWK
@@ -138,7 +109,7 @@
       args: "{{ connection_options }}"
       register: jwk_again
 
-    - name: Change the claim
+    - name: Change the claim, still without a reload
       matonb.step.provisioner:
         name: cicd
         type: JWK
@@ -156,7 +127,24 @@
           - drift.updated == ['x509_min']
         fail_msg: "Claim reconciliation did not behave in config mode"
 
-    - name: Reload before removing, so list and ca.json agree
+    # Under the #31 bug this is a silent no-op rather than a failure: the module
+    # does not see acme in the CA's loaded configuration, so it reports ok and
+    # leaves the provisioner in ca.json.
+    - name: Remove the ACME provisioner, still without a reload
+      matonb.step.provisioner:
+        name: acme
+        state: absent
+      args: "{{ connection_options }}"
+      register: acme_remove
+
+    - name: Assert removal happened and demands a restart too
+      ansible.builtin.assert:
+        that:
+          - acme_remove is changed
+          - acme_remove.restart_required
+        fail_msg: "Config mode removal did not behave"
+
+    - name: Reload the CA once, as restart_required asked
       ansible.builtin.command: "docker kill -s HUP {{ container }}"
       changed_when: true
 
@@ -164,23 +152,69 @@
       ansible.builtin.uri:
         ca_path: "{{ ca_dir }}/certs/root_ca.crt"
         url: "{{ ca_url }}/provisioners"
-      register: settled
+      register: after_reload
       until: >-
         'cicd' in
-        (settled.json.provisioners | map(attribute='name') | list)
+        (after_reload.json.provisioners | map(attribute='name') | list)
       retries: 15
       delay: 2
 
-    - name: Remove the ACME provisioner
-      matonb.step.provisioner:
-        name: acme
-        state: absent
-      args: "{{ connection_options }}"
-      register: acme_remove
-
-    - name: Assert removal demands a restart too
+    - name: Assert the running CA converged on what ca.json says
       ansible.builtin.assert:
         that:
-          - acme_remove is changed
-          - acme_remove.restart_required
-        fail_msg: "Config mode removal did not behave"
+          - >-
+            'acme' not in
+            (after_reload.json.provisioners | map(attribute='name') | list)
+          - >-
+            (after_reload.json.provisioners
+             | selectattr('name', 'equalto', 'cicd')
+             | map(attribute='claims.minTLSCertDuration')
+             | first) == '45m0s'
+        fail_msg: >-
+          After the reload the CA should serve exactly what ca.json holds:
+          cicd with a 45m minimum, and no acme
+
+    # The README and examples/ both claim config-mode tasks do not need a
+    # running CA, which rests on the step CLI falling back to editing ca.json
+    # when it cannot reach one. Pin it rather than trust it.
+    - name: Stop the CA entirely
+      ansible.builtin.command: "docker stop -t 3 {{ container }}"
+      changed_when: true
+
+    - name: Add a provisioner with no CA running at all
+      matonb.step.provisioner:
+        name: offline
+        type: ACME
+      args: "{{ connection_options }}"
+      register: offline_add
+
+    - name: Re-run with the CA still down
+      matonb.step.provisioner:
+        name: offline
+        type: ACME
+      args: "{{ connection_options }}"
+      register: offline_again
+
+    - name: Assert the change landed and is still idempotent
+      ansible.builtin.assert:
+        that:
+          - offline_add is changed
+          - offline_add.management_mode == 'config'
+          - offline_add.restart_required
+          - offline_again is not changed
+        fail_msg: "Config mode should work against a stopped CA"
+
+    - name: Start the CA again
+      ansible.builtin.command: "docker start {{ container }}"
+      changed_when: true
+
+    - name: The CA serves what was written while it was down
+      ansible.builtin.uri:
+        ca_path: "{{ ca_dir }}/certs/root_ca.crt"
+        url: "{{ ca_url }}/provisioners"
+      register: restarted
+      until: >-
+        'offline' in
+        (restarted.json.provisioners | map(attribute='name') | list)
+      retries: 30
+      delay: 2

--- a/tests/unit/plugins/module_utils/test_connection.py
+++ b/tests/unit/plugins/module_utils/test_connection.py
@@ -22,6 +22,8 @@ from ansible_collections.matonb.step.plugins.module_utils.connection import (
     StepConnection,
     configured_mode,
     observed_mode,
+    read_authority,
+    read_provisioners,
 )
 
 # Every subcommand the module can issue.
@@ -288,6 +290,53 @@ class TestConfiguredMode:
         connection = StepConnection(ca_path=str(tmp_path), ca_config=str(elsewhere))
         assert connection.config_file() == str(elsewhere)
         assert configured_mode(connection)[0] is ManagementMode.ADMIN
+
+    def test_a_null_authority_reads_as_config_not_a_crash(self, tmp_path):
+        # Previously this raised AttributeError out of configured_mode and
+        # reached the user as a traceback. An absent authority block means
+        # admin was never enabled, which is config mode.
+        mode, error = configured_mode(self.write_ca_json(tmp_path, None))
+        assert (mode, error) == (ManagementMode.CONFIG, None)
+
+    def test_a_non_object_authority_reports_an_error(self, tmp_path):
+        mode, error = configured_mode(self.write_ca_json(tmp_path, "nonsense"))
+        assert mode is None
+        assert "not a JSON object" in error
+
+
+class TestCaJsonStructure:
+    """Telling "nothing configured" apart from "this file is not a ca.json"."""
+
+    @pytest.mark.parametrize(
+        "config",
+        [{}, {"authority": None}, {"authority": {}}],
+        ids=["empty", "null-authority", "empty-authority"],
+    )
+    def test_an_absent_authority_block_reads_as_empty(self, config):
+        assert read_authority(config, "ca.json") == ({}, None)
+
+    @pytest.mark.parametrize("config", [["array"], "string", 3, None], ids=["array", "string", "int", "null"])
+    def test_a_file_that_is_not_an_object_is_an_error(self, config):
+        authority, error = read_authority(config, "ca.json")
+        assert (authority, "does not hold a JSON object" in error) == ({}, True)
+
+    def test_provisioners_are_returned_verbatim(self):
+        entries = [{"name": "acme", "type": "ACME"}]
+        assert read_provisioners({"authority": {"provisioners": entries}}, "ca.json") == (entries, None)
+
+    @pytest.mark.parametrize(
+        ("config", "expected"),
+        [
+            ({"authority": {"provisioners": {"acme": {}}}}, "is not a list"),
+            ({"authority": {"provisioners": ["acme"]}}, "entry that is not a JSON object"),
+            ({"authority": "nonsense"}, "not a JSON object"),
+        ],
+        ids=["mapping", "list-of-strings", "bad-authority"],
+    )
+    def test_a_misshapen_provisioner_list_is_an_error(self, config, expected):
+        entries, error = read_provisioners(config, "ca.json")
+        assert entries == []
+        assert expected in error
 
 
 class TestEnvironment:

--- a/tests/unit/plugins/module_utils/test_provisioner.py
+++ b/tests/unit/plugins/module_utils/test_provisioner.py
@@ -9,7 +9,7 @@ import subprocess
 
 import pytest
 
-from ansible_collections.matonb.step.plugins.module_utils.connection import StepConnection
+from ansible_collections.matonb.step.plugins.module_utils.connection import ManagementMode, StepConnection
 from ansible_collections.matonb.step.plugins.module_utils.provisioner import (
     COMMAND_TIMEOUT,
     X509_CLAIMS,
@@ -33,9 +33,9 @@ def completed(stdout="", stderr=""):
 class RecordingConnection(StepConnection):
     """A StepConnection that records commands instead of running them."""
 
-    def __init__(self, stdout="[]", error=None):
+    def __init__(self, stdout="[]", error=None, **connection):
         """Record commands, optionally raising instead of running."""
-        super().__init__()
+        super().__init__(**connection)
         object.__setattr__(self, "calls", [])
         object.__setattr__(self, "timeouts", [])
         object.__setattr__(self, "_stdout", stdout)
@@ -148,16 +148,24 @@ class TestAddArguments:
             GenericProvisioner(name="o", type="OIDC").add_arguments()
 
 
+def write_ca_config(tmp_path, provisioners, key="provisioners"):
+    """Write a ca.json holding the given provisioner entries."""
+    config_file = tmp_path / "ca.json"
+    config_file.write_text(json.dumps({"authority": {key: provisioners}}), encoding="utf-8")
+    return str(config_file)
+
+
 class TestStepProvisionerClient:
-    def test_list_parses_every_reported_provisioner(self):
+    def test_admin_mode_reads_the_running_ca(self):
         payload = json.dumps([{"name": "admin", "type": "JWK"}, {"name": "corp", "type": "OIDC"}])
         client = StepProvisionerClient(RecordingConnection(stdout=payload))
-        assert [(p.name, p.type) for p in client.list()] == [("admin", "JWK"), ("corp", "OIDC")]
+        listed = client.list(ManagementMode.ADMIN)
+        assert [(p.name, p.type) for p in listed] == [("admin", "JWK"), ("corp", "OIDC")]
 
     def test_list_rejects_output_that_is_not_json(self):
         client = StepProvisionerClient(RecordingConnection(stdout="not json"))
         with pytest.raises(RuntimeError, match="JSON"):
-            client.list()
+            client.list(ManagementMode.ADMIN)
 
     def test_add_builds_the_expected_command(self, tmp_path, monkeypatch):
         monkeypatch.setattr("tempfile.tempdir", str(tmp_path))
@@ -198,8 +206,114 @@ class TestStepProvisionerClient:
         monkeypatch.setattr("tempfile.tempdir", str(tmp_path))
         connection = RecordingConnection()
         client = StepProvisionerClient(connection)
-        client.list()
+        client.list(ManagementMode.ADMIN)
         client.add("acme", "ACME", NO_CLAIMS)
         client.update("acme", NO_CLAIMS)
         client.remove("acme")
         assert connection.timeouts == [COMMAND_TIMEOUT] * 4
+
+
+class TestConfigModeListing:
+    """Config mode must read ca.json, the file add/update/remove write to.
+
+    Reading the CA instead reports its *loaded* configuration, so a task
+    re-running before step-ca has been sent SIGHUP does not see the provisioner
+    it just created and tries to create it again (issue #31).
+    """
+
+    def test_provisioners_come_from_ca_json_without_running_a_command(self, tmp_path):
+        config_file = write_ca_config(
+            tmp_path,
+            [{"name": "acme", "type": "ACME"}, {"name": "cicd", "type": "JWK"}],
+        )
+        connection = RecordingConnection(ca_config=config_file)
+        listed = StepProvisionerClient(connection).list(ManagementMode.CONFIG)
+
+        assert [(p.name, p.type) for p in listed] == [("acme", "ACME"), ("cicd", "JWK")]
+        # The CA is never consulted, so this works with step-ca stopped.
+        assert connection.calls == []
+
+    def test_ca_json_is_located_under_ca_path(self, tmp_path):
+        (tmp_path / "config").mkdir()
+        write_ca_config(tmp_path / "config", [{"name": "acme", "type": "ACME"}])
+        connection = RecordingConnection(ca_path=str(tmp_path))
+        listed = StepProvisionerClient(connection).list(ManagementMode.CONFIG)
+        assert [p.name for p in listed] == ["acme"]
+
+    def test_claims_survive_the_change_of_source(self, tmp_path):
+        # Drift detection compares against these, so they have to arrive intact.
+        config_file = write_ca_config(
+            tmp_path,
+            [{"name": "cicd", "type": "JWK", "claims": {"minTLSCertDuration": "20m0s"}}],
+        )
+        listed = StepProvisionerClient(RecordingConnection(ca_config=config_file)).list(ManagementMode.CONFIG)
+        assert claim_drift({**NO_CLAIMS, "x509_min": "20m"}, listed[0].claims) == []
+
+    def test_either_source_yields_the_same_provisioner(self, tmp_path):
+        # ca.json entries and endpoint entries are the same shape; if they ever
+        # diverge, build_provisioner() needs to know about it.
+        entry = {"name": "cicd", "type": "JWK", "key": {"kid": "abc"}, "encryptedKey": "enc"}
+        from_ca = StepProvisionerClient(RecordingConnection(stdout=json.dumps([entry]))).list(ManagementMode.ADMIN)
+        from_config = StepProvisionerClient(RecordingConnection(ca_config=write_ca_config(tmp_path, [entry]))).list(
+            ManagementMode.CONFIG
+        )
+        assert from_ca[0].to_dict() == from_config[0].to_dict()
+
+    def test_a_ca_json_with_no_provisioners_is_empty_not_an_error(self, tmp_path):
+        connection = RecordingConnection(ca_config=write_ca_config(tmp_path, None))
+        assert StepProvisionerClient(connection).list(ManagementMode.CONFIG) == []
+
+    @pytest.mark.parametrize(
+        "contents",
+        ["{}", '{"authority": null}', '{"authority": {}}', '{"authority": {"provisioners": null}}'],
+        ids=["empty", "null-authority", "empty-authority", "null-provisioners"],
+    )
+    def test_nothing_configured_is_empty_not_an_error(self, tmp_path, contents):
+        # A CA with no provisioners yet is ordinary, and must not be confused
+        # with a ca.json that could not be understood.
+        config_file = tmp_path / "ca.json"
+        config_file.write_text(contents, encoding="utf-8")
+        connection = RecordingConnection(ca_config=str(config_file))
+        assert StepProvisionerClient(connection).list(ManagementMode.CONFIG) == []
+
+    @pytest.mark.parametrize(
+        ("contents", "expected"),
+        [
+            (None, "File not found"),
+            ("{ not json", "Invalid JSON"),
+            ('["an", "array"]', "does not hold a JSON object"),
+            ('{"authority": "nonsense"}', "'authority' entry .* is not a JSON object"),
+            ('{"authority": {"provisioners": {"acme": {}}}}', "'authority.provisioners' .* is not a list"),
+            ('{"authority": {"provisioners": ["acme"]}}', "entry that is not a JSON object"),
+        ],
+        ids=["missing", "malformed", "not-an-object", "authority-not-an-object", "not-a-list", "entry-not-an-object"],
+    )
+    def test_an_unusable_ca_json_raises_and_never_falls_back(self, tmp_path, contents, expected):
+        # Falling back to the CA here would silently reintroduce the very
+        # read/write split this exists to close.
+        config_file = tmp_path / "ca.json"
+        if contents is not None:
+            config_file.write_text(contents, encoding="utf-8")
+
+        connection = RecordingConnection(ca_config=str(config_file))
+        with pytest.raises(RuntimeError, match=expected):
+            StepProvisionerClient(connection).list(ManagementMode.CONFIG)
+        assert connection.calls == []
+
+    def test_an_unreadable_ca_json_raises_and_never_falls_back(self, tmp_path):
+        config_file = tmp_path / "ca.json"
+        config_file.write_text("{}", encoding="utf-8")
+        config_file.chmod(0o000)
+        connection = RecordingConnection(ca_config=str(config_file))
+        try:
+            with pytest.raises(RuntimeError, match="Permission denied"):
+                StepProvisionerClient(connection).list(ManagementMode.CONFIG)
+        finally:
+            config_file.chmod(0o600)
+        assert connection.calls == []
+
+    def test_no_ca_path_or_ca_config_names_both_options(self, tmp_path):
+        connection = RecordingConnection()
+        with pytest.raises(RuntimeError, match=r"'ca_path'.*'ca_config'"):
+            StepProvisionerClient(connection).list(ManagementMode.CONFIG)
+        assert connection.calls == []

--- a/tests/unit/plugins/modules/test_provisioner.py
+++ b/tests/unit/plugins/modules/test_provisioner.py
@@ -171,10 +171,29 @@ class TestResolveMode:
         module = FakeModule(name="acme", management_mode="admin")
         assert resolve_mode(module, _connection(module)) is ManagementMode.ADMIN
 
-    def test_auto_falls_back_to_config_with_a_warning(self):
+    def test_explicit_admin_mode_needs_no_ca_json(self):
+        # The way out for anyone reaching the CA by ca_url alone.
+        module = FakeModule(name="acme", management_mode="admin", ca_url="https://ca.example.com")
+        assert resolve_mode(module, _connection(module)) is ManagementMode.ADMIN
+
+    def test_auto_reads_enable_admin(self, tmp_path):
+        config_file = tmp_path / "ca.json"
+        config_file.write_text('{"authority": {"enableAdmin": true}}', encoding="utf-8")
+        module = FakeModule(name="acme", management_mode="auto", ca_config=str(config_file))
+        assert resolve_mode(module, _connection(module)) is ManagementMode.ADMIN
+
+    def test_auto_fails_rather_than_guessing_a_mode(self):
+        # Assuming 'config' against an admin CA reads the wrong source and
+        # writes a file the running CA will never load.
         module = FakeModule(name="acme", management_mode="auto")
-        assert resolve_mode(module, _connection(module)) is ManagementMode.CONFIG
-        assert module.warnings
+        with pytest.raises(ModuleFailedError, match="Cannot determine the management mode"):
+            resolve_mode(module, _connection(module))
+        assert module.warnings == []
+
+    def test_the_failure_names_both_ways_out(self, tmp_path):
+        module = FakeModule(name="acme", management_mode="auto", ca_path=str(tmp_path / "absent"))
+        with pytest.raises(ModuleFailedError, match=r"'ca_path'.*'management_mode'"):
+            resolve_mode(module, _connection(module))
 
 
 class TestBuildCredentials:


### PR DESCRIPTION
Closes #31. Closes #21.

## The bug (312a1bf)

In config mode the module read provisioners from a different source than it
wrote them to. `step ca provisioner list` queries the CA's `/provisioners`
endpoint — the configuration the running CA has **loaded** — while
`add`/`update`/`remove` edit `ca.json` on disk. Until step-ca is sent SIGHUP the
two disagree, so re-running a play before the reload did not see the provisioner
it had just created and tried again:

```
error storing provisioner: provisioner with name acme already exists
```

`state: absent` was worse: a silent `ok` while the provisioner stayed in the
file. Admin mode was unaffected — there both the read and the write go through
the CA.

`list()` now takes the resolved mode and, in config mode, reads
`authority.provisioners` from `ca.json`. An unreadable `ca.json` is an error
rather than a fall back to the endpoint, because a silent fallback reintroduces
exactly this split.

**Config mode no longer needs a running CA**, so provisioners can be configured
before step-ca is ever started. The integration suite stops the container
outright to pin that.

### Mode resolution no longer guesses

Reading `authority.enableAdmin` is *detection*, not inference — it is the field
step-ca itself reads. But when `ca.json` cannot be reached the mode is genuinely
unknown, and assuming `config` against an admin CA sends reads to the wrong
source and writes to a file the CA will never load. The task now fails naming
both remedies rather than warning and picking one.

### Notes for existing users

- **`ca_path` or `ca_config` is now required**, unless `management_mode: admin`.
  A task that set neither previously carried on with a warning; it now fails.
  That configuration was already writing to a `ca.json` the module could not
  identify. Also affects a `ca_path` not containing `config/ca.json` (the
  containerised case) and a `ca.json` unreadable without `become`. README has an
  upgrade note.
- `restart_required` is unchanged. This alters what the module *reads*, not
  whether a reload is needed.
- A null or misshapen `authority` block now reports an actionable error instead
  of an `AttributeError` traceback.

## Examples (afea62b)

#21 asked for update support, which landed in 1.1.0 — claim drift is compared
numerically, reconciled with `step ca provisioner update`, and the reconciled
claims are named in `updated`. The one requirement never met was an examples
folder. One playbook per situation, linted in CI alongside `roles/` and
`plugins/` so an option rename breaks them rather than leaving them to rot — as
the README examples had, still advertising `x509_min_dur` and friends.

## Verification

| | |
| --- | --- |
| `pytest tests/unit -q` | 221 passed (was 188) |
| `ansible-test sanity` | clean |
| `ansible-test units` | 64 + 157 = 221 passed |
| `pre-commit run --all-files` | clean |
| `ansible-lint examples/` | clean, production profile |
| `tests/integration/run.sh` | both modes pass |

`tests/integration/config_mode.yml` is the regression test: it was written
first and **confirmed to fail on the previous code** with the exact error from
#31, before any module change.

## Not included

- `galaxy.yml` version — python-semantic-release derives it from the commit
  type, as in 1d611ac.
- No trigger for the integration suite; it still runs when someone remembers.
