### PR TITLE
fix(configure): report changed accurately and declare dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Modify Step CA configuration JSON file (ca.json). Supports top-level parameters 
 
 **Note**: Step CA must be restarted after configuration changes.
 
+The file is only rewritten when a requested setting differs from what it already
+holds, so `changed` is accurate and a `notify` handler fires only on a real
+change. Durations are compared as durations rather than as text — step
+renormalises `8760h` to `8760h0m0s` when it rewrites `ca.json`, and that is not
+treated as a change. Settings this module does not manage are left untouched.
+
 ### Parameters
 
 | Parameter                   | Type   | Required | Default | Description                               |
@@ -29,7 +35,7 @@ Modify Step CA configuration JSON file (ca.json). Supports top-level parameters 
 | `crt`                       | path   | no       |         | Path to certificate file                  |
 | `db_datasource`             | string | no       |         | Database datasource string                |
 | `default_tls_cert_duration` | string | no       |         | Default TLS cert duration (e.g., "720h")  |
-| `json_path`                 | path   | yes      |         | Path to the ca.json configuration file    |
+| `json_path`                 | string | yes      |         | Path to the ca.json configuration file    |
 | `key`                       | path   | no       |         | Path to key file                          |
 | `max_tls_cert_duration`     | string | no       |         | Maximum TLS cert duration (e.g., "8760h") |
 | `min_tls_cert_duration`     | string | no       |         | Minimum TLS cert duration (e.g., "5m")    |

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -50,7 +50,10 @@ tags:
 
 # Collections that this one depends on, in the format
 # 'namespace.name': 'version'
-dependencies: {}
+# community.general supplies community.general.capabilities, used by the
+# ca_server role to grant step-ca CAP_NET_BIND_SERVICE.
+dependencies:
+  community.general: '>=1.0.0'
 
 # Metadata URLs (optional but helpful)
 repository: https://github.com/matonb/step

--- a/plugins/modules/configure.py
+++ b/plugins/modules/configure.py
@@ -15,10 +15,18 @@ description:
     become the CA-wide defaults inherited by provisioners that do not set
     their own.
   - step-ca must be restarted or sent SIGHUP for changes to take effect.
-notes:
   - >-
-    This module always reports C(changed) as true, even when the requested
-    settings already match the file.
+    The file is only rewritten when a requested setting differs from what it
+    already holds, so C(changed) is accurate and a C(notify) handler fires only
+    on a real change. Settings this module does not manage are left untouched.
+  - >-
+    Durations are compared as durations rather than as text, because step
+    renormalises them when it rewrites C(ca.json): a claim set here as C(8760h)
+    is written back as C(8760h0m0s). The two mean the same thing and are not
+    treated as a change.
+  - >-
+    Supports check mode. Under C(--check) the resulting configuration is
+    computed and returned, and C(changed) is predicted, but nothing is written.
 options:
   ca_config:
     description:
@@ -103,12 +111,12 @@ EXAMPLES = r"""
 
 RETURN = r"""
 changed:
-  description: Always true when the module runs to completion.
+  description: Whether the file had to be rewritten.
   returned: success
   type: bool
 
 msg:
-  description: Confirmation that the file was written.
+  description: Whether the file was written or already held the requested settings.
   returned: success
   type: str
 
@@ -118,12 +126,26 @@ new_data:
   type: dict
 """
 
+import copy
 import json
 import os
 
 from ansible.module_utils.basic import AnsibleModule
 
+from ansible_collections.matonb.step.plugins.module_utils.utils import parse_duration
+
 ENCODING = "utf-8"
+
+# Options written to the top level of ca.json, unchanged.
+TOP_LEVEL_KEYS = ("ca_config", "ca_path", "crt", "db_datasource", "key", "root")
+
+# Options written under authority.claims, where they become the CA-wide
+# defaults inherited by provisioners that do not set their own.
+CLAIM_KEYS = {
+    "default_tls_cert_duration": "defaultTLSCertDuration",
+    "max_tls_cert_duration": "maxTLSCertDuration",
+    "min_tls_cert_duration": "minTLSCertDuration",
+}
 
 
 def load_json_file(json_path):
@@ -148,9 +170,73 @@ def save_json_file(json_path, data):
     return {"success": True}
 
 
-def main():
-    """Run the Ansible module."""
-    module_args = {
+def _already_expresses(stored, wanted_nanoseconds):
+    """Whether a stored claim already means the requested duration.
+
+    Args:
+        stored: The value currently in the file.
+        wanted_nanoseconds: The requested duration, already parsed.
+
+    Returns:
+        bool: True if the two are the same duration. A stored value that
+        cannot be parsed is treated as different, so it gets corrected.
+    """
+    try:
+        return parse_duration(str(stored)) == wanted_nanoseconds
+    except ValueError:
+        return False
+
+
+def apply_updates(config, params):
+    """Apply the requested settings to a copy of the configuration.
+
+    Returning a new object rather than mutating in place is what lets the
+    caller compare before and after, and so report C(changed) accurately.
+
+    Args:
+        config: The configuration as read from disk.
+        params: The module parameters.
+
+    Returns:
+        dict: The configuration with the requested settings applied.
+
+    Raises:
+        ValueError: If a requested duration cannot be parsed.
+    """
+    updated = copy.deepcopy(config)
+    updated.update({key: params[key] for key in TOP_LEVEL_KEYS if params[key] is not None})
+
+    requested = {key: params[key] for key in CLAIM_KEYS if params[key] is not None}
+    if not requested:
+        return updated
+
+    claims = updated.setdefault("authority", {}).setdefault("claims", {})
+    for key, value in requested.items():
+        try:
+            wanted = parse_duration(value)
+        except ValueError as exc:
+            raise ValueError(f"Invalid value for '{key}': {exc}") from exc
+
+        claim = CLAIM_KEYS[key]
+        # Durations are compared as durations, not as text. step renormalises
+        # what it writes - a claim set here as 8760h comes back as 8760h0m0s
+        # once step has rewritten ca.json - and rewriting that to the requested
+        # spelling would report changed on every run and restart the CA with
+        # it, while meaning exactly the same thing.
+        if claim in claims and _already_expresses(claims[claim], wanted):
+            continue
+        claims[claim] = value
+
+    return updated
+
+
+def get_argument_spec():
+    """Return the argument spec for the configure module.
+
+    Returns:
+        dict: The module's argument specification.
+    """
+    return {
         "ca_config": {"type": "path", "required": False, "default": None},
         "ca_path": {"type": "path", "required": False, "default": None},
         "crt": {"type": "path", "required": False, "default": None},
@@ -163,47 +249,37 @@ def main():
         "root": {"type": "path", "required": False, "default": None},
     }
 
-    module = AnsibleModule(argument_spec=module_args, supports_check_mode=True)
+
+def main():
+    """Run the Ansible module."""
+    module = AnsibleModule(argument_spec=get_argument_spec(), supports_check_mode=True)
 
     json_path = module.params["json_path"]
-
-    # Top-level parameters
-    top_level_keys = ["ca_config", "ca_path", "crt", "db_datasource", "key", "root"]
-    updates = {key: module.params[key] for key in top_level_keys if module.params[key] is not None}
-
-    # Claims parameters (nested under authority.claims)
-    claims_map = {
-        "max_tls_cert_duration": "maxTLSCertDuration",
-        "default_tls_cert_duration": "defaultTLSCertDuration",
-        "min_tls_cert_duration": "minTLSCertDuration",
-    }
-    claims_updates = {claims_map[key]: module.params[key] for key in claims_map if module.params[key] is not None}
 
     json_data = load_json_file(json_path)
 
     if "error" in json_data:
         module.fail_json(msg=json_data["error"])
 
-    # Apply top-level updates
-    json_data.update(updates)
+    try:
+        new_data = apply_updates(json_data, module.params)
+    except ValueError as exc:
+        module.fail_json(msg=str(exc))
 
-    # Apply claims updates under authority.claims
-    if claims_updates:
-        if "authority" not in json_data:
-            json_data["authority"] = {}
-        if "claims" not in json_data["authority"]:
-            json_data["authority"]["claims"] = {}
-        json_data["authority"]["claims"].update(claims_updates)
+    # Rewriting a file that already says the right thing would report changed
+    # on every run, and any notify handler would restart the CA with it.
+    if new_data == json_data:
+        module.exit_json(changed=False, msg="Configuration already up to date", new_data=new_data)
 
     if module.check_mode:
-        module.exit_json(changed=True, new_data=json_data)
+        module.exit_json(changed=True, msg="Configuration would be updated", new_data=new_data)
 
-    result = save_json_file(json_path, json_data)
+    result = save_json_file(json_path, new_data)
 
     if "error" in result:
         module.fail_json(msg=result["error"])
 
-    module.exit_json(changed=True, msg="JSON file updated", new_data=json_data)
+    module.exit_json(changed=True, msg="JSON file updated", new_data=new_data)
 
 
 if __name__ == "__main__":

--- a/tests/unit/plugins/modules/test_configure.py
+++ b/tests/unit/plugins/modules/test_configure.py
@@ -1,0 +1,310 @@
+# Copyright: (c) 2025, Brett Maton <matonb@users.noreply.github.com>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Tests for the configure module's update logic.
+
+The module previously reported C(changed) unconditionally, so a play using the
+documented C(notify: restart step-ca) pattern restarted the CA on every run.
+These tests pin the comparison that stopped that.
+"""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from ansible_collections.matonb.step.plugins.modules import configure
+from ansible_collections.matonb.step.plugins.modules.configure import (
+    CLAIM_KEYS,
+    TOP_LEVEL_KEYS,
+    apply_updates,
+    get_argument_spec,
+)
+
+# Sourced from the real spec so an option that stops being written shows up
+# here, rather than only in the constants the module happens to still list.
+NOTHING_REQUESTED = dict.fromkeys(set(get_argument_spec()) - {"json_path"})
+
+
+def params(**requested):
+    """Build module parameters with only the named options set."""
+    unknown = set(requested) - set(NOTHING_REQUESTED)
+    if unknown:
+        raise AssertionError(f"not module options: {sorted(unknown)}")
+    return {**NOTHING_REQUESTED, **requested}
+
+
+class TestOptionCoverage:
+    def test_every_option_is_written_somewhere(self):
+        # Without this, deleting an entry from TOP_LEVEL_KEYS makes the module
+        # silently stop writing that option while every other test still
+        # passes: they all derive their parameters from those same constants.
+        assert set(get_argument_spec()) - {"json_path"} == set(TOP_LEVEL_KEYS) | set(CLAIM_KEYS)
+
+    def test_the_claim_names_are_the_ones_step_reads(self):
+        # Asserted as literals, because everything else in this file takes the
+        # names from CLAIM_KEYS itself: a typo there would write a claim
+        # step-ca silently ignores, and no other test would notice.
+        assert CLAIM_KEYS == {
+            "default_tls_cert_duration": "defaultTLSCertDuration",
+            "max_tls_cert_duration": "maxTLSCertDuration",
+            "min_tls_cert_duration": "minTLSCertDuration",
+        }
+
+
+class TestChangeDetection:
+    """apply_updates returns something equal to its input when nothing differs.
+
+    main() reports changed on exactly that comparison, so these are the tests
+    that keep the CA from being restarted on every play.
+    """
+
+    def test_requesting_nothing_changes_nothing(self):
+        config = {"root": "/etc/step-ca/certs/root_ca.crt", "authority": {"claims": {"maxTLSCertDuration": "8760h"}}}
+        assert apply_updates(config, params()) == config
+
+    def test_requesting_what_is_already_set_changes_nothing(self):
+        config = {"root": "/root.crt", "authority": {"claims": {"maxTLSCertDuration": "8760h"}}}
+        updated = apply_updates(config, params(root="/root.crt", max_tls_cert_duration="8760h"))
+        assert updated == config
+
+    def test_a_differing_top_level_value_changes_the_result(self):
+        config = {"root": "/old.crt"}
+        assert apply_updates(config, params(root="/new.crt")) != config
+
+    def test_a_differing_claim_changes_the_result(self):
+        config = {"authority": {"claims": {"maxTLSCertDuration": "8760h"}}}
+        assert apply_updates(config, params(max_tls_cert_duration="17520h")) != config
+
+    @pytest.mark.parametrize(
+        ("stored", "requested"),
+        [
+            ("8760h0m0s", "8760h"),
+            ("5m0s", "5m"),
+            ("1h30m0s", "90m"),
+            ("1h6m0s", "1.1h"),
+            ("8760h", "8760h"),
+        ],
+        ids=["hours", "minutes", "mixed-units", "fractional", "identical"],
+    )
+    def test_a_renormalised_duration_is_not_a_change(self, stored, requested):
+        # step rewrites ca.json's claims in its own spelling: a value set here
+        # as 8760h comes back as 8760h0m0s. Comparing the text would report a
+        # change on every run and restart the CA each time, forever.
+        config = {"authority": {"claims": {"maxTLSCertDuration": stored}}}
+        assert apply_updates(config, params(max_tls_cert_duration=requested)) == config
+
+    def test_a_genuinely_different_duration_is_still_a_change(self):
+        config = {"authority": {"claims": {"maxTLSCertDuration": "8760h0m0s"}}}
+        assert apply_updates(config, params(max_tls_cert_duration="8761h")) != config
+
+    def test_an_unparseable_stored_duration_is_corrected(self):
+        # Whatever put "forever" there, it is not a duration step can read.
+        config = {"authority": {"claims": {"maxTLSCertDuration": "forever"}}}
+        updated = apply_updates(config, params(max_tls_cert_duration="8760h"))
+        assert updated["authority"]["claims"]["maxTLSCertDuration"] == "8760h"
+
+    def test_an_unparseable_requested_duration_names_the_option(self):
+        with pytest.raises(ValueError, match="max_tls_cert_duration"):
+            apply_updates({}, params(max_tls_cert_duration="forever"))
+
+
+class TestUpdates:
+    def test_the_input_is_never_mutated(self):
+        # main() compares against the original, so mutating it would make every
+        # run report no change - the opposite failure, and a silent one.
+        config = {"root": "/old.crt", "authority": {"claims": {"maxTLSCertDuration": "1h"}}}
+        apply_updates(config, params(root="/new.crt", max_tls_cert_duration="2h"))
+        assert config == {"root": "/old.crt", "authority": {"claims": {"maxTLSCertDuration": "1h"}}}
+
+    @pytest.mark.parametrize("key", TOP_LEVEL_KEYS)
+    def test_every_top_level_option_is_written_at_the_top_level(self, key):
+        assert apply_updates({}, params(**{key: "value"})) == {key: "value"}
+
+    @pytest.mark.parametrize(("key", "claim"), sorted(CLAIM_KEYS.items()))
+    def test_every_duration_option_is_written_under_authority_claims(self, key, claim):
+        assert apply_updates({}, params(**{key: "5m"})) == {"authority": {"claims": {claim: "5m"}}}
+
+    def test_unmanaged_settings_are_preserved(self):
+        # ca.json holds far more than this module knows about; anything it does
+        # not manage must survive untouched.
+        config = {
+            "address": ":443",
+            "authority": {"claims": {"minTLSCertDuration": "5m"}, "provisioners": [{"name": "acme"}]},
+            "dnsNames": ["ca.example.com"],
+        }
+        updated = apply_updates(config, params(max_tls_cert_duration="8760h"))
+        assert updated["address"] == ":443"
+        assert updated["dnsNames"] == ["ca.example.com"]
+        assert updated["authority"]["provisioners"] == [{"name": "acme"}]
+        assert updated["authority"]["claims"]["minTLSCertDuration"] == "5m"
+
+    def test_claims_are_created_when_the_file_has_no_authority_block(self):
+        assert apply_updates({}, params(min_tls_cert_duration="5m")) == {
+            "authority": {"claims": {"minTLSCertDuration": "5m"}}
+        }
+
+    def test_an_existing_authority_block_is_not_replaced(self):
+        config = {"authority": {"enableAdmin": True}}
+        updated = apply_updates(config, params(min_tls_cert_duration="5m"))
+        assert updated["authority"]["enableAdmin"] is True
+        assert updated["authority"]["claims"] == {"minTLSCertDuration": "5m"}
+
+
+def run_module(json_path, **requested):
+    """Execute the module the way Ansible does and return its result.
+
+    Driving main() rather than apply_updates is what pins the reported
+    `changed` value: the original defect was in main() alone, and every
+    apply_updates test would have passed with it still in place.
+
+    The child inherits the environment but not this process's sys.path, which
+    is where conftest made `ansible_collections.matonb.step` importable, so it
+    is handed over rather than recomputed. Only the entries that actually carry
+    collections are passed: exporting the whole path would also export pytest's
+    insertion of this test's own directory, letting it shadow stdlib imports in
+    the child. `ansible` itself comes from the interpreter's own site-packages.
+    """
+    args = json.dumps({"ANSIBLE_MODULE_ARGS": {"json_path": str(json_path), **requested}})
+    collection_paths = [path for path in sys.path if path and os.path.isdir(os.path.join(path, "ansible_collections"))]
+    completed = subprocess.run(
+        [sys.executable, configure.__file__],
+        input=args,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "PYTHONPATH": os.pathsep.join(collection_paths)},
+    )
+    if not completed.stdout:
+        # Without this the failure surfaces as a JSONDecodeError and the real
+        # traceback, which is on stderr, is thrown away.
+        raise AssertionError(f"module produced no result (exit {completed.returncode}):\n{completed.stderr}")
+    return json.loads(completed.stdout)
+
+
+class TestReportedChangedState:
+    """The module as Ansible actually invokes it.
+
+    A play following the documented `notify: restart step-ca` pattern restarts
+    the CA whenever this reports changed, so an unconditional true meant a CA
+    restart on every single run.
+    """
+
+    def test_first_run_changes_the_file_and_the_second_does_not(self, tmp_path):
+        config_file = tmp_path / "ca.json"
+        config_file.write_text(json.dumps({"address": ":443"}), encoding="utf-8")
+
+        first = run_module(config_file, max_tls_cert_duration="8760h")
+        second = run_module(config_file, max_tls_cert_duration="8760h")
+
+        assert first["changed"] is True
+        assert second["changed"] is False
+        assert json.loads(config_file.read_text(encoding="utf-8")) == {
+            "address": ":443",
+            "authority": {"claims": {"maxTLSCertDuration": "8760h"}},
+        }
+
+    def test_a_no_op_run_leaves_the_file_byte_for_byte_alone(self, tmp_path):
+        # Not just "changed is false" - the file must not be rewritten at all,
+        # or anything watching its mtime sees churn.
+        config_file = tmp_path / "ca.json"
+        run_module(config_file, max_tls_cert_duration="8760h")
+        before = config_file.read_bytes()
+        mtime = config_file.stat().st_mtime_ns
+
+        assert run_module(config_file, max_tls_cert_duration="8760h")["changed"] is False
+        assert config_file.read_bytes() == before
+        assert config_file.stat().st_mtime_ns == mtime
+
+    def test_a_changed_setting_is_reported_and_written(self, tmp_path):
+        config_file = tmp_path / "ca.json"
+        run_module(config_file, max_tls_cert_duration="8760h")
+
+        result = run_module(config_file, max_tls_cert_duration="17520h")
+
+        assert result["changed"] is True
+        assert result["new_data"]["authority"]["claims"]["maxTLSCertDuration"] == "17520h"
+
+    def test_check_mode_predicts_without_writing(self, tmp_path):
+        config_file = tmp_path / "ca.json"
+        config_file.write_text(json.dumps({"address": ":443"}), encoding="utf-8")
+
+        result = run_module(config_file, max_tls_cert_duration="8760h", _ansible_check_mode=True)
+
+        assert result["changed"] is True
+        assert json.loads(config_file.read_text(encoding="utf-8")) == {"address": ":443"}
+
+    def test_check_mode_reports_no_change_when_already_correct(self, tmp_path):
+        config_file = tmp_path / "ca.json"
+        run_module(config_file, max_tls_cert_duration="8760h")
+
+        result = run_module(config_file, max_tls_cert_duration="8760h", _ansible_check_mode=True)
+
+        assert result["changed"] is False
+
+    def test_a_renormalised_file_is_left_alone_end_to_end(self, tmp_path):
+        # The realistic case: this module wrote 8760h, then step rewrote ca.json
+        # while adding a provisioner and normalised it to 8760h0m0s. Re-running
+        # the same play must not report changed.
+        config_file = tmp_path / "ca.json"
+        config_file.write_text(
+            json.dumps({"authority": {"claims": {"maxTLSCertDuration": "8760h0m0s"}}}),
+            encoding="utf-8",
+        )
+        before = config_file.read_bytes()
+
+        result = run_module(config_file, max_tls_cert_duration="8760h")
+
+        assert result["changed"] is False
+        assert config_file.read_bytes() == before
+
+    def test_every_exit_carries_a_message(self, tmp_path):
+        config_file = tmp_path / "ca.json"
+        changed = run_module(config_file, max_tls_cert_duration="8760h")
+        unchanged = run_module(config_file, max_tls_cert_duration="8760h")
+        predicted = run_module(config_file, max_tls_cert_duration="17520h", _ansible_check_mode=True)
+
+        assert changed["msg"] == "JSON file updated"
+        assert unchanged["msg"] == "Configuration already up to date"
+        assert predicted["msg"] == "Configuration would be updated"
+
+
+class TestFailures:
+    def test_a_malformed_ca_json_fails_with_an_explanation(self, tmp_path):
+        config_file = tmp_path / "ca.json"
+        config_file.write_text("{ not json", encoding="utf-8")
+
+        result = run_module(config_file, max_tls_cert_duration="8760h")
+
+        assert result["failed"] is True
+        assert "Failed to load JSON file" in result["msg"]
+
+    @pytest.mark.skipif(os.geteuid() == 0, reason="root ignores directory permissions")
+    def test_an_unwritable_path_fails_with_an_explanation(self, tmp_path):
+        unwritable = tmp_path / "readonly"
+        unwritable.mkdir()
+        unwritable.chmod(0o500)
+        try:
+            result = run_module(unwritable / "ca.json", max_tls_cert_duration="8760h")
+        finally:
+            unwritable.chmod(0o700)
+
+        assert result["failed"] is True
+        assert "Failed to write JSON file" in result["msg"]
+
+    def test_an_invalid_duration_names_the_option(self, tmp_path):
+        result = run_module(tmp_path / "ca.json", max_tls_cert_duration="forever")
+
+        assert result["failed"] is True
+        assert "max_tls_cert_duration" in result["msg"]
+
+    def test_requesting_nothing_against_a_missing_file_creates_nothing(self, tmp_path):
+        # Behaviour change: this used to write a file containing "{}", which was
+        # never a usable ca.json, and reported changed for doing so.
+        config_file = tmp_path / "ca.json"
+
+        result = run_module(config_file)
+
+        assert result["changed"] is False
+        assert not config_file.exists()


### PR DESCRIPTION
Two defects found while assessing whether the collection is production ready.

## `configure` restarted the CA on every run

It called `exit_json(changed=True)` unconditionally — its own `notes:`
documented this. Paired with the `notify: restart step-ca` pattern the README
teaches, that meant a CA restart on every single Ansible run, and a certificate
issuance blip with it.

It now applies the requested settings to a copy, compares, and writes only when
something differs. Check mode predicts the same comparison instead of always
claiming a change.

### Durations are compared as durations

The naive fix is not enough. `step` renormalises `authority.claims` when it
rewrites `ca.json` — which it does whenever a provisioner is managed in config
mode — so a value set as `8760h` comes back as `8760h0m0s`. A textual comparison
would have left the CA restarting on every run for the three options this module
is most used for.

`utils.parse_duration` already existed for exactly this comparison in the
provisioner module. An unparseable *stored* value is corrected; an unparseable
*requested* value fails naming the option.

## `galaxy.yml` declared no dependencies

`roles/ca_server` uses `community.general.capabilities`. Installing this
collection from Galaxy into a clean environment produced a role that could not
resolve the module. Now declares `community.general: '>=1.0.0'` — verified as
the correct floor, and as the only external FQCN in the collection.

## Tests

The module had none, which is why the `changed` defect survived. It has 38 now.

The ones that matter drive `main()` as a subprocess with `ANSIBLE_MODULE_ARGS`
on stdin, the way Ansible invokes it. That is deliberate: my first 18 tests only
exercised the extracted helper and **would all have passed with the original
defect still in place**.

Mutation-tested — each of these fails tests:

| Reintroduced defect | Tests failed |
| --- | --- |
| Unconditional `changed=True` | 6 |
| Textual duration comparison | 5 |
| Dropping an option from `TOP_LEVEL_KEYS` | 2 |
| Typo in the `defaultTLSCertDuration` wire name | 1 |

## Verification

| | |
| --- | --- |
| `pytest tests/unit -q` | 259 passed (was 221) |
| `ansible-test sanity` | clean |
| `ansible-test units` | 102 + 157 = 259 passed |
| `pre-commit run --all-files` | clean |
| `ansible-lint roles/ plugins/ examples/` | clean, production profile |

## Behaviour changes

- A `notify` handler on `configure` now fires only on real changes. That is the
  fix, but anyone relying on the restart-every-run side effect loses it.
- A run against a nonexistent `json_path` with no options set no longer creates
  a file containing `{}`. Pinned by a test.

## Not included

Raised separately, deliberately out of scope: `load_json_file` returning `{}`
for a missing file so a typo'd path silently creates a config; the non-atomic
write with no `backup` option; `configure.py` duplicating the JSON helpers in
`module_utils/utils.py`; `json_path` typed `str` while every other path option
is `path`.
