### PR TITLE
fix(initialize): never delete the CA during a check-mode run

### DIFF
--- a/plugins/modules/initialize.py
+++ b/plugins/modules/initialize.py
@@ -80,6 +80,11 @@ options:
     description:
       - Replace any existing certificates, secrets and configuration found at I(path).
       - Without this the module fails rather than overwrite an existing CA.
+      - >-
+        This deletes C(secrets/root_ca_key), which cannot be regenerated:
+        everything the old CA issued becomes unverifiable and the trust chain
+        has to be rebuilt from scratch. Nothing is backed up. Under C(--check)
+        the deletion is reported but not performed.
     required: false
     type: bool
     default: false
@@ -254,13 +259,24 @@ management_mode:
 import os
 import pathlib
 import re
-from typing import Any, Optional
+from typing import Any
 
 from ansible.module_utils.basic import AnsibleModule
 
 from ansible_collections.matonb.step.plugins.module_utils.process import (
     CommandTimeoutError,
     run_command,
+)
+
+# The files `step ca init` creates. Their presence is what makes a directory an
+# initialised CA, and what `force` deletes.
+CA_FILE_NAMES = (
+    "certs/intermediate_ca.crt",
+    "certs/root_ca.crt",
+    "config/ca.json",
+    "config/defaults.json",
+    "secrets/intermediate_ca_key",
+    "secrets/root_ca_key",
 )
 
 
@@ -385,39 +401,46 @@ def build_initialize_command(params: dict[str, Any]) -> list[str]:
     return cmd
 
 
-def check_existing_ca_files(step_path: str, force: bool = False) -> Optional[str]:
-    """Check if CA files already exist and handle them based on the force parameter.
+def ca_file_paths(step_path: str) -> list[str]:
+    """Return the full paths of the files C(step ca init) creates.
 
     Args:
-        step_path: The path to the Step CA directory
-        force: Whether to force deletion of existing files
+        step_path: The path to the Step CA directory.
 
     Returns:
-        Optional[str]: Error message if files exist and force is False, None otherwise
+        List[str]: The paths, in a stable order.
     """
-    step_files = [
-        f"{step_path}/certs/intermediate_ca.crt",
-        f"{step_path}/certs/root_ca.crt",
-        f"{step_path}/config/ca.json",
-        f"{step_path}/config/defaults.json",
-        f"{step_path}/secrets/intermediate_ca_key",
-        f"{step_path}/secrets/root_ca_key",
-    ]
+    return [os.path.join(step_path, name) for name in CA_FILE_NAMES]
 
-    if force:
-        for file in step_files:
-            pathlib.Path(file).unlink(missing_ok=True)
-        return None
 
-    file_found = next((file for file in step_files if os.path.exists(file)), None)
-    if file_found:
-        return (
-            f"Found {file_found}, cannot continue.\n"
-            "Use force: true to override or ensure that none of the "
-            "following files exist:\n" + "\n".join(step_files)
-        )
+def find_existing_ca_files(step_path: str) -> list[str]:
+    """Report which of the CA's files are already present.
 
-    return None
+    Detection only. Deletion is :func:`remove_ca_files`, kept separate so that
+    the caller can decide - the two used to be one function, which meant asking
+    whether a CA existed destroyed it.
+
+    Args:
+        step_path: The path to the Step CA directory.
+
+    Returns:
+        List[str]: The paths that exist, empty if the directory holds no CA.
+    """
+    return [path for path in ca_file_paths(step_path) if os.path.exists(path)]
+
+
+def remove_ca_files(step_path: str) -> None:
+    """Delete the files C(step ca init) creates.
+
+    Irreversible: C(secrets/root_ca_key) cannot be regenerated, and everything
+    the CA ever issued becomes unverifiable without it. Only ever call this
+    when C(force) was asked for and the module is not in check mode.
+
+    Args:
+        step_path: The path to the Step CA directory.
+    """
+    for path in ca_file_paths(step_path):
+        pathlib.Path(path).unlink(missing_ok=True)
 
 
 def validate_admin_options(module: AnsibleModule) -> None:
@@ -494,19 +517,38 @@ def main() -> None:
     management_mode = "admin" if module.params.get("remote_management") else "config"
     admin_subject = module.params.get("admin_subject") or ("step" if management_mode == "admin" else None)
 
-    # Check for existing CA files
-    error_msg = check_existing_ca_files(step_path, force=module.params.get("force", False))
-    if error_msg:
-        module.fail_json(msg=error_msg)
+    existing = find_existing_ca_files(step_path)
+    if existing and not module.params["force"]:
+        module.fail_json(
+            msg=(
+                f"Found {existing[0]}, cannot continue.\n"
+                "Use force: true to override or ensure that none of the "
+                "following files exist:\n" + "\n".join(ca_file_paths(step_path))
+            )
+        )
 
-    # In check mode, report that changes would be made
+    # Nothing above this line modifies anything, and nothing below it may run
+    # under check mode: with force: true the next step deletes the CA's private
+    # keys. Detection and deletion used to be one call placed above this guard,
+    # so a --check run destroyed the CA and then reported what it "would" do.
     if module.check_mode:
         module.exit_json(
             changed=True,
-            msg="Check mode: Step CA would be initialized",
+            msg=(
+                "Check mode: the existing CA would be deleted and Step CA reinitialized"
+                if existing
+                else "Check mode: Step CA would be initialized"
+            ),
             admin_subject=admin_subject,
             management_mode=management_mode,
         )
+
+    # Keyed on force rather than on what was detected: find_existing_ca_files
+    # uses os.path.exists, which is False for a symlink whose target is gone,
+    # and step would then meet a directory it expected to be empty. Unreachable
+    # without force, because the fail_json above has already returned.
+    if module.params["force"]:
+        remove_ca_files(step_path)
 
     # Run step CA initialization
     try:

--- a/tests/unit/plugins/modules/test_initialize.py
+++ b/tests/unit/plugins/modules/test_initialize.py
@@ -2,12 +2,20 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 """Tests for building the `step ca init` command and its option guards."""
 
+import json
+import os
+import subprocess
+import sys
+
 import pytest
 
+from ansible_collections.matonb.step.plugins.modules import initialize
 from ansible_collections.matonb.step.plugins.modules.initialize import (
+    CA_FILE_NAMES,
     build_initialize_command,
-    check_existing_ca_files,
+    find_existing_ca_files,
     get_argument_spec,
+    remove_ca_files,
     validate_admin_options,
 )
 
@@ -117,20 +125,202 @@ class TestArgumentSpec:
         assert set(get_argument_spec()["deployment_type"]["choices"]) == {"hosted", "linked", "standalone"}
 
 
-class TestCheckExistingCaFiles:
-    def test_empty_directory_is_acceptable(self, tmp_path):
-        assert check_existing_ca_files(str(tmp_path)) is None
+def build_ca(tmp_path):
+    """Populate a directory with every file `step ca init` creates."""
+    for name in CA_FILE_NAMES:
+        path = tmp_path / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(f"PRECIOUS-{name}", encoding="utf-8")
+    return [tmp_path / name for name in CA_FILE_NAMES]
+
+
+class TestFindExistingCaFiles:
+    """Detection must never delete. It used to, which is what caused #35."""
+
+    def test_an_empty_directory_holds_no_ca(self, tmp_path):
+        assert find_existing_ca_files(str(tmp_path)) == []
 
     def test_an_existing_ca_is_reported(self, tmp_path):
         (tmp_path / "config").mkdir()
         (tmp_path / "config" / "ca.json").write_text("{}")
-        message = check_existing_ca_files(str(tmp_path))
-        assert message is not None
-        assert "ca.json" in message
+        assert find_existing_ca_files(str(tmp_path)) == [str(tmp_path / "config" / "ca.json")]
 
-    def test_force_clears_the_way(self, tmp_path):
+    def test_a_complete_ca_reports_every_file(self, tmp_path):
+        build_ca(tmp_path)
+        assert find_existing_ca_files(str(tmp_path)) == [str(tmp_path / name) for name in CA_FILE_NAMES]
+
+    def test_detection_leaves_everything_in_place(self, tmp_path):
+        # The heart of #35: asking whether a CA exists must not destroy it.
+        files = build_ca(tmp_path)
+        find_existing_ca_files(str(tmp_path))
+        assert all(path.exists() for path in files)
+
+    def test_the_file_list_is_the_one_step_creates(self):
+        # Asserted as literals: every other test here takes the names from
+        # CA_FILE_NAMES, so dropping the root key from it would go unnoticed
+        # and force would silently stop removing it.
+        assert CA_FILE_NAMES == (
+            "certs/intermediate_ca.crt",
+            "certs/root_ca.crt",
+            "config/ca.json",
+            "config/defaults.json",
+            "secrets/intermediate_ca_key",
+            "secrets/root_ca_key",
+        )
+
+
+class TestRemoveCaFiles:
+    def test_every_file_is_removed(self, tmp_path):
+        files = build_ca(tmp_path)
+        remove_ca_files(str(tmp_path))
+        assert not [path for path in files if path.exists()]
+
+    def test_a_partial_ca_is_not_an_error(self, tmp_path):
         (tmp_path / "config").mkdir()
-        target = tmp_path / "config" / "ca.json"
-        target.write_text("{}")
-        assert check_existing_ca_files(str(tmp_path), force=True) is None
-        assert not target.exists()
+        (tmp_path / "config" / "ca.json").write_text("{}")
+        remove_ca_files(str(tmp_path))
+        assert find_existing_ca_files(str(tmp_path)) == []
+
+
+def stub_step_binary(tmp_path):
+    """Put a `step` on PATH that always fails, and return the env to use.
+
+    Without this, a test that reaches the real `step ca init` behaves
+    differently on every host: absent in CI, refusing for want of a terminal
+    under a pipe, and - for a developer running pytest in their own shell -
+    opening /dev/tty to prompt for DNS names, which blocks until the command
+    timeout. It also couples the assertion to step continuing to refuse to run
+    non-interactively.
+    """
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    stub = bin_dir / "step"
+    stub.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+    stub.chmod(0o755)
+    return {"PATH": os.pathsep.join([str(bin_dir), os.environ.get("PATH", "")])}
+
+
+def run_module(step_path, password_file, extra_env=None, **requested):
+    """Execute the module the way Ansible does and return its result.
+
+    Driving main() is the only way to catch #35: the defect was purely the
+    order of two calls, so every test of the functions themselves passed with
+    it in place.
+    """
+    args = json.dumps(
+        {
+            "ANSIBLE_MODULE_ARGS": {
+                "name": "Test CA",
+                "path": str(step_path),
+                "password_file": str(password_file),
+                "provisioner_password_file": str(password_file),
+                **requested,
+            }
+        }
+    )
+    collection_paths = [path for path in sys.path if path and os.path.isdir(os.path.join(path, "ansible_collections"))]
+    completed = subprocess.run(
+        [sys.executable, initialize.__file__],
+        input=args,
+        capture_output=True,
+        text=True,
+        check=False,
+        env={**os.environ, "PYTHONPATH": os.pathsep.join(collection_paths), **(extra_env or {})},
+    )
+    if not completed.stdout:
+        raise AssertionError(f"module produced no result (exit {completed.returncode}):\n{completed.stderr}")
+    return json.loads(completed.stdout)
+
+
+class TestCheckModeNeverDeletes:
+    """Regression tests for #35.
+
+    `check_existing_ca_files()` both detected and deleted, and ran before the
+    check-mode guard, so `--check` with `force: true` unlinked the CA's private
+    keys and then reported what it "would" do. The root CA key cannot be
+    regenerated.
+    """
+
+    def test_check_mode_with_force_leaves_an_existing_ca_intact(self, tmp_path):
+        ca = tmp_path / "ca"
+        ca.mkdir()
+        files = build_ca(ca)
+        password_file = tmp_path / "pw"
+        password_file.write_text("pw", encoding="utf-8")
+
+        result = run_module(ca, password_file, force=True, _ansible_check_mode=True)
+
+        assert result["changed"] is True
+        assert [path.name for path in files if not path.exists()] == []
+        assert all(path.read_text(encoding="utf-8").startswith("PRECIOUS-") for path in files)
+
+    def test_check_mode_with_force_says_it_would_delete(self, tmp_path):
+        # Reporting `changed` is not enough: an operator running --check to find
+        # out what force does needs to be told the CA goes away.
+        ca = tmp_path / "ca"
+        ca.mkdir()
+        build_ca(ca)
+        password_file = tmp_path / "pw"
+        password_file.write_text("pw", encoding="utf-8")
+
+        result = run_module(ca, password_file, force=True, _ansible_check_mode=True)
+
+        assert "deleted" in result["msg"]
+
+    def test_check_mode_without_force_still_refuses_and_deletes_nothing(self, tmp_path):
+        ca = tmp_path / "ca"
+        ca.mkdir()
+        files = build_ca(ca)
+        password_file = tmp_path / "pw"
+        password_file.write_text("pw", encoding="utf-8")
+
+        result = run_module(ca, password_file, _ansible_check_mode=True)
+
+        assert "cannot continue" in result["msg"]
+        assert all(path.exists() for path in files)
+
+    def test_check_mode_on_an_empty_directory_creates_nothing(self, tmp_path):
+        ca = tmp_path / "ca"
+        ca.mkdir()
+        password_file = tmp_path / "pw"
+        password_file.write_text("pw", encoding="utf-8")
+
+        result = run_module(ca, password_file, _ansible_check_mode=True)
+
+        assert result["changed"] is True
+        assert list(ca.iterdir()) == []
+
+
+class TestForceOutsideCheckMode:
+    def test_force_still_removes_an_existing_ca(self, tmp_path):
+        # The other half of the fix: moving the deletion below the check-mode
+        # guard must not stop it happening on a real run. The stubbed step
+        # fails, so nothing is recreated and the deletion is observable.
+        ca = tmp_path / "ca"
+        ca.mkdir()
+        files = build_ca(ca)
+        password_file = tmp_path / "pw"
+        password_file.write_text("pw", encoding="utf-8")
+
+        result = run_module(ca, password_file, force=True, extra_env=stub_step_binary(tmp_path))
+
+        assert result["failed"] is True
+        assert [path for path in files if path.exists()] == []
+
+    def test_without_force_a_real_run_refuses_and_deletes_nothing(self, tmp_path):
+        # The production path. Check mode is covered above; if the guard on the
+        # no-force branch were weakened, only this test would notice - and this
+        # is the run that would actually overwrite a CA nobody asked to replace.
+        ca = tmp_path / "ca"
+        ca.mkdir()
+        files = build_ca(ca)
+        password_file = tmp_path / "pw"
+        password_file.write_text("pw", encoding="utf-8")
+
+        result = run_module(ca, password_file, extra_env=stub_step_binary(tmp_path))
+
+        # The message matters, not just the failure: with the guard removed the
+        # module reaches step, which also fails, so asserting `failed` alone
+        # passes either way and proves nothing.
+        assert "cannot continue" in result["msg"]
+        assert all(path.read_text(encoding="utf-8").startswith("PRECIOUS-") for path in files)


### PR DESCRIPTION
Closes #35.

## The bug

`matonb.step.initialize` deleted the CA's private keys during a `--check` run
when `force: true` was set, and did not recreate them.

`check_existing_ca_files()` both detected *and* deleted — with `force=True` it
unlinked all six CA files — and `main()` called it **above** the check-mode
guard. Control then reached the check-mode branch and returned before any
initialization.

Reproduced before the fix:

```
=== before ===  6 files, including secrets/root_ca_key

{"changed": true, "msg": "Check mode: Step CA would be initialized"}

=== after ===   (no files)
```

`secrets/root_ca_key` cannot be regenerated: everything the CA issued becomes
unverifiable and the trust chain has to be rebuilt. `--check` is what an operator
runs to find out what `force` does *before* committing to it, so this fired
exactly when someone was being careful.

## The fix

One function that lied about what it did becomes three that don't:

| | |
| --- | --- |
| `ca_file_paths()` | pure path building from the new `CA_FILE_NAMES` constant |
| `find_existing_ca_files()` | detection only — cannot delete, because it no longer can |
| `remove_ca_files()` | deletion only |

`main()` detects, fails if files exist without `force`, hits the check-mode
guard, and only then deletes. Verified by tracing every call above the guard —
`validate_admin_options`, the `helm` branch, the mode computation — none touch
the filesystem.

Deletion stays keyed on `force` rather than on what detection returned.
`os.path.exists` is false for a symlink whose target is missing while `unlink`
removes the link itself, so keying on the detected list would leave a dangling
`root_ca_key` symlink for `step ca init` to trip over.

`force` now documents that it destroys the root key irreversibly with no backup,
which it never said.

## Tests

Driving `main()` as a subprocess is the point: the defect was purely the order of
two calls, so every test of the functions in isolation passed with it in place.

The `step` binary is stubbed rather than invoked. The real one opens `/dev/tty`
directly and prompts for DNS names, which blocked until the command timeout for
anyone running `pytest` in a terminal with the step CLI installed — 15s per run,
and it coupled the assertion to step continuing to refuse non-interactive use.

Mutation-tested:

| Reintroduced defect | Tests failed |
| --- | --- |
| Deletion moved back above the check-mode guard (#35 itself) | 1 |
| The no-force guard weakened | 2 |

The second mutation initially failed only 1 test and caught a flaw in a test I
had just added: it asserted `failed is True`, which the stubbed `step` satisfies
regardless of whether the guard refused. It now asserts on the message.

## Verification

| | |
| --- | --- |
| Original reproduction re-run | 6 files in, 6 out, root key content intact |
| `pytest tests/unit -q` | 269 passed (was 259) |
| `ansible-test sanity` | clean |
| `ansible-test units` | 112 + 157 = 269 passed |
| `pre-commit run --all-files` | clean |

## Not included

#36 — check mode without `force` against an existing CA still fails rather than
reporting `ok`. Separate issue, and this change makes it easier rather than
harder: that branch is now a plain `if existing:` with a detection result in
hand, instead of a function that deleted as a side effect of being asked a
question.
