### PR TITLE
feat(configure): write ca.json atomically via the shared helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,34 @@ change. Durations are compared as durations rather than as text — step
 renormalises `8760h` to `8760h0m0s` when it rewrites `ca.json`, and that is not
 treated as a change. Settings this module does not manage are left untouched.
 
+The file is replaced atomically — written alongside, flushed, and moved into
+place in one step — so a failed or interrupted write leaves the original intact
+rather than truncated. An existing file keeps its mode and ownership; a file
+created by `create: true` takes the running user's umask, since this module sets
+neither. A symlinked `json_path` is followed rather than replaced. Set
+`backup: true` to keep a timestamped copy of what was there before.
+
 ### Parameters
 
-| Parameter                   | Type   | Required | Default | Description                               |
-| --------------------------- | ------ | -------- | ------- | ----------------------------------------- |
-| `ca_config`                 | path   | no       |         | Path to CA config file                    |
-| `ca_path`                   | path   | no       |         | Path to CA directory                      |
-| `crt`                       | path   | no       |         | Path to certificate file                  |
-| `db_datasource`             | string | no       |         | Database datasource string                |
-| `default_tls_cert_duration` | string | no       |         | Default TLS cert duration (e.g., "720h")  |
-| `json_path`                 | string | yes      |         | Path to the ca.json configuration file    |
-| `key`                       | path   | no       |         | Path to key file                          |
-| `max_tls_cert_duration`     | string | no       |         | Maximum TLS cert duration (e.g., "8760h") |
-| `min_tls_cert_duration`     | string | no       |         | Minimum TLS cert duration (e.g., "5m")    |
-| `root`                      | path   | no       |         | Path to root certificate                  |
+| Parameter                   | Type    | Required | Default | Description                                         |
+| --------------------------- | ------- | -------- | ------- | --------------------------------------------------- |
+| `backup`                    | boolean | no       | `false` | Copy the file before overwriting; see `backup_file` |
+| `ca_config`                 | path    | no       |         | Path to CA config file                              |
+| `ca_path`                   | path    | no       |         | Path to CA directory                                |
+| `create`                    | boolean | no       | `false` | Write a new file when `json_path` does not exist    |
+| `crt`                       | path    | no       |         | Path to certificate file                            |
+| `db_datasource`             | string  | no       |         | Database datasource string                          |
+| `default_tls_cert_duration` | string  | no       |         | Default TLS cert duration (e.g., "720h")            |
+| `json_path`                 | path    | yes      |         | Path to the ca.json configuration file              |
+| `key`                       | path    | no       |         | Path to key file                                    |
+| `max_tls_cert_duration`     | string  | no       |         | Maximum TLS cert duration (e.g., "8760h")           |
+| `min_tls_cert_duration`     | string  | no       |         | Minimum TLS cert duration (e.g., "5m")              |
+| `root`                      | path    | no       |         | Path to root certificate                            |
+
+`json_path` must already exist unless `create: true`. A path that is not there
+is far more often a typo than a request to build a CA configuration from
+nothing, and the old behaviour — writing a new, nearly empty file and reporting
+success — left the real CA untouched with the play still green.
 
 ### Examples
 
@@ -202,6 +216,17 @@ callback logs. Set `no_log: true` on the task, or supply `password` yourself, if
 that matters to you.
 
 ### Upgrading from 1.1.x
+
+Two changes to `matonb.step.configure`, both closing
+[#37](https://github.com/matonb/step/issues/37):
+
+- **A missing `json_path` now fails** rather than creating a new file. Set
+  `create: true` if a task genuinely builds a configuration from nothing.
+- **`json_path` expands `~`**, having previously been typed `str` while
+  `ca_path` and `ca_config` beside it were `path`. The two combined badly: a
+  `~/step-ca/config/ca.json` produced a literal `~` directory.
+
+Then, for `matonb.step.provisioner`:
 
 **`ca_path` or `ca_config` is now required, unless you set
 `management_mode: admin`.** Two things that used to work by reaching the CA over

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -213,19 +213,63 @@ def read_json_file(json_file: str) -> tuple[Optional[dict[str, Any]], Optional[s
         return None, f"Invalid data in file: {value_error}"
 
 
-def save_json_file(json_path: str, data: dict[str, Any]) -> dict[str, Any]:
-    """Save JSON data to a file.
+def save_json_file(module, json_path: str, data: dict[str, Any]) -> Optional[str]:
+    """Write JSON to a file atomically, replacing it in one step.
+
+    Writing in place would empty the file before the new contents were
+    complete, so an interruption or a serialisation error would leave a CA
+    configuration that step-ca cannot load. Serialising to a temporary file
+    first means the original survives every failure: either the replacement
+    succeeds whole, or nothing happened at all.
+
+    The temporary file goes in the target's own directory because a rename is
+    only atomic within a single filesystem, and the move is delegated to
+    C(AnsibleModule.atomic_move), which preserves an existing destination's
+    mode, ownership and SELinux context. A destination that does not exist yet
+    is created with the running user's umask.
+
+    A symlink is followed rather than replaced, so a C(ca.json) that points
+    elsewhere keeps pointing there and the file it names is what gets updated.
 
     Args:
+        module: The Ansible module instance, used for the atomic move.
         json_path: The file path where the data will be saved.
         data: The JSON-serializable data to write.
 
     Returns:
-        dict: Success or error information.
+        str or None: An error message, or None on success.
     """
+    target = os.path.realpath(json_path)
+    directory = os.path.dirname(target) or "."
     try:
-        with open(json_path, "w", encoding=ENCODING) as file:
-            json.dump(data, file, indent=4)
+        handle, temporary = tempfile.mkstemp(dir=directory, prefix=".matonb-step-", suffix=".json")
     except OSError as error:
-        return {"error": f"Failed to write JSON file: {str(error)}"}
-    return {"success": True}
+        return f"Failed to write JSON file '{target}': {error}"
+
+    try:
+        with os.fdopen(handle, "w", encoding=ENCODING) as file:
+            json.dump(data, file, indent=4)
+            file.flush()
+            # Without this the rename can be committed before the data behind
+            # it, so a power loss leaves an empty file where the CA config was.
+            os.fsync(file.fileno())
+        # atomic_move raises a bare Exception on failure, and older cores call
+        # fail_json instead, which is a SystemExit. Catching only OSError left
+        # the temporary file behind and lost the error - and a bind-mounted
+        # ca.json gives EBUSY on rename, so this is an ordinary case, not an
+        # exotic one.
+        module.atomic_move(temporary, target)
+    except Exception as error:
+        return f"Failed to write JSON file '{target}': {error}"
+    finally:
+        # The original is untouched whatever happened; take the half-written
+        # copy with us. A finally rather than an except branch because older
+        # cores fail_json inside atomic_move, and that SystemExit has to keep
+        # propagating while still leaving no temporary file behind.
+        if os.path.exists(temporary):
+            try:
+                os.remove(temporary)
+            except OSError:
+                pass
+
+    return None

--- a/plugins/modules/configure.py
+++ b/plugins/modules/configure.py
@@ -27,7 +27,24 @@ description:
   - >-
     Supports check mode. Under C(--check) the resulting configuration is
     computed and returned, and C(changed) is predicted, but nothing is written.
+  - >-
+    The file is replaced atomically: the new contents are written alongside it,
+    flushed to disk, and moved into place in one step, so a failed or
+    interrupted write leaves the original exactly as it was rather than
+    truncated. An existing file keeps its mode and ownership; ownership is only
+    preserved when the module runs privileged enough to set it.
+  - >-
+    A symlinked I(json_path) is followed, so the file it names is updated and
+    the link is left alone.
 options:
+  backup:
+    description:
+      - Copy the existing file, with a timestamp, before overwriting it.
+      - The path of the copy is returned as I(backup_file).
+    required: false
+    type: bool
+    default: false
+    version_added: "1.2.0"
   ca_config:
     description:
       - Path to the CA configuration file, written to the top level of C(ca.json).
@@ -38,6 +55,20 @@ options:
       - Path to the CA directory, written to the top level of C(ca.json).
     required: false
     type: path
+  create:
+    description:
+      - Write a new configuration file when I(json_path) does not exist.
+      - >-
+        Off by default, so a mistyped path fails instead of silently producing
+        a new, nearly empty configuration while the real CA is left untouched.
+      - >-
+        A file created this way takes the running user's umask and ownership;
+        this module sets neither. Use C(ansible.builtin.file) afterwards if it
+        needs specific permissions.
+    required: false
+    type: bool
+    default: false
+    version_added: "1.2.0"
   crt:
     description:
       - Path to the intermediate certificate, written to the top level of C(ca.json).
@@ -57,8 +88,9 @@ options:
   json_path:
     description:
       - Path to the C(ca.json) configuration file to modify.
+      - Must already exist unless I(create) is set.
     required: true
-    type: str
+    type: path
   key:
     description:
       - Path to the intermediate private key, written to the top level of C(ca.json).
@@ -110,6 +142,12 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+backup_file:
+  description: Path to the copy taken before the file was overwritten.
+  returned: when I(backup) is true and the file existed and was changed
+  type: str
+  sample: /etc/step-ca/config/ca.json.42.2026-08-05@18:22:14~
+
 changed:
   description: Whether the file had to be rewritten.
   returned: success
@@ -127,14 +165,15 @@ new_data:
 """
 
 import copy
-import json
 import os
 
 from ansible.module_utils.basic import AnsibleModule
 
-from ansible_collections.matonb.step.plugins.module_utils.utils import parse_duration
-
-ENCODING = "utf-8"
+from ansible_collections.matonb.step.plugins.module_utils.utils import (
+    parse_duration,
+    read_json_file,
+    save_json_file,
+)
 
 # Options written to the top level of ca.json, unchanged.
 TOP_LEVEL_KEYS = ("ca_config", "ca_path", "crt", "db_datasource", "key", "root")
@@ -148,26 +187,43 @@ CLAIM_KEYS = {
 }
 
 
-def load_json_file(json_path):
-    """Load JSON data from a file."""
+def load_configuration(module, json_path):
+    """Read the configuration to be updated.
+
+    A file that is simply not there is only acceptable when the task asked for
+    it to be created. Treating a missing file as an empty one means a mistyped
+    path writes a brand new, nearly empty configuration and reports success
+    while the real CA is untouched.
+
+    Args:
+        module: The Ansible module instance, used to fail.
+        json_path: Path to the configuration file.
+
+    Returns:
+        dict: The parsed configuration, empty if it is being created.
+    """
     if not os.path.exists(json_path):
+        if not module.params["create"]:
+            module.fail_json(
+                msg=(
+                    f"'{json_path}' does not exist. Check the path, or set 'create: true' to write a "
+                    "new configuration file there."
+                )
+            )
         return {}
 
-    try:
-        with open(json_path, encoding=ENCODING) as file:
-            return json.load(file)
-    except (OSError, json.JSONDecodeError) as error:
-        return {"error": f"Failed to load JSON file: {str(error)}"}
+    config, error = read_json_file(json_path)
+    if error:
+        module.fail_json(msg=f"Failed to load JSON file: {error}")
+    if not isinstance(config, dict):
+        module.fail_json(msg=f"'{json_path}' does not hold a JSON object.")
+    # Checked one level down as well, because that is where the claims go: an
+    # authority holding anything but an object reaches setdefault() and
+    # surfaces as an AttributeError traceback rather than something to act on.
+    if not isinstance(config.get("authority", {}), dict):
+        module.fail_json(msg=f"The 'authority' entry in '{json_path}' is not a JSON object.")
 
-
-def save_json_file(json_path, data):
-    """Save JSON data to a file."""
-    try:
-        with open(json_path, "w", encoding=ENCODING) as file:
-            json.dump(data, file, indent=4)
-    except OSError as error:
-        return {"error": f"Failed to write JSON file: {str(error)}"}
-    return {"success": True}
+    return config
 
 
 def _already_expresses(stored, wanted_nanoseconds):
@@ -237,12 +293,14 @@ def get_argument_spec():
         dict: The module's argument specification.
     """
     return {
+        "backup": {"type": "bool", "required": False, "default": False},
         "ca_config": {"type": "path", "required": False, "default": None},
         "ca_path": {"type": "path", "required": False, "default": None},
+        "create": {"type": "bool", "required": False, "default": False},
         "crt": {"type": "path", "required": False, "default": None},
         "db_datasource": {"type": "str", "required": False, "default": None},
         "default_tls_cert_duration": {"type": "str", "required": False, "default": None},
-        "json_path": {"type": "str", "required": True},
+        "json_path": {"type": "path", "required": True},
         "key": {"type": "path", "required": False, "default": None},
         "max_tls_cert_duration": {"type": "str", "required": False, "default": None},
         "min_tls_cert_duration": {"type": "str", "required": False, "default": None},
@@ -256,10 +314,7 @@ def main():
 
     json_path = module.params["json_path"]
 
-    json_data = load_json_file(json_path)
-
-    if "error" in json_data:
-        module.fail_json(msg=json_data["error"])
+    json_data = load_configuration(module, json_path)
 
     try:
         new_data = apply_updates(json_data, module.params)
@@ -274,12 +329,24 @@ def main():
     if module.check_mode:
         module.exit_json(changed=True, msg="Configuration would be updated", new_data=new_data)
 
-    result = save_json_file(json_path, new_data)
+    result = {"changed": True, "msg": "JSON file updated", "new_data": new_data}
 
-    if "error" in result:
-        module.fail_json(msg=result["error"])
+    if module.params["backup"] and os.path.exists(json_path):
+        try:
+            result["backup_file"] = module.backup_local(json_path)
+        except Exception as exc:
+            # backup_local raises rather than returning, so without this an
+            # unwritable directory reports MODULE FAILURE and a traceback.
+            module.fail_json(msg=f"Failed to back up '{json_path}': {exc}")
 
-    module.exit_json(changed=True, msg="JSON file updated", new_data=new_data)
+    error = save_json_file(module, json_path, new_data)
+    if error:
+        failure = {"msg": error}
+        if "backup_file" in result:
+            failure["backup_file"] = result["backup_file"]
+        module.fail_json(**failure)
+
+    module.exit_json(**result)
 
 
 if __name__ == "__main__":

--- a/tests/unit/plugins/module_utils/test_utils.py
+++ b/tests/unit/plugins/module_utils/test_utils.py
@@ -2,8 +2,10 @@
 # GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
 """Tests for duration parsing and secret file handling."""
 
+import json
 import os
 import pathlib
+import shutil
 import stat
 
 import pytest
@@ -11,6 +13,7 @@ import pytest
 from ansible_collections.matonb.step.plugins.module_utils.utils import (
     generate_secure_password,
     parse_duration,
+    save_json_file,
     write_secret_file,
 )
 
@@ -113,3 +116,129 @@ class TestGenerateSecurePassword:
         assert any(c.islower() for c in password)
         assert any(c.isdigit() for c in password)
         assert any(not c.isalnum() for c in password)
+
+
+# The exceptions atomic_move really raises. A bind-mounted ca.json - which is
+# how this collection's own integration suite runs - gives EBUSY on rename, and
+# ansible-core turns that into a bare Exception.
+MOVE_FAILURES = [
+    OSError("no space left on device"),
+    Exception("Unable to make temporary file into ca.json, failed final rename"),
+]
+
+
+class FakeModule:
+    """Stands in for AnsibleModule's atomic_move, which is all this needs."""
+
+    def __init__(self, raises=None):
+        """Optionally make the move fail with the given exception instance.
+
+        The real atomic_move does not raise OSError: current ansible-core
+        raises a bare Exception, and older cores call fail_json, which is a
+        SystemExit. Modelling only OSError here is exactly what let a handler
+        that caught only OSError look correct.
+        """
+        self.raises = raises
+        self.moves = []
+
+    def atomic_move(self, src, dest):
+        self.moves.append((src, dest))
+        if self.raises is not None:
+            raise self.raises
+        shutil.move(src, dest)
+
+
+class TestSaveJsonFile:
+    """The write must not be able to destroy what it is replacing.
+
+    Writing in place truncates first, so an interruption leaves a ca.json
+    step-ca cannot load and there is nothing to restore from.
+    """
+
+    def test_the_data_round_trips(self, tmp_path):
+        target = tmp_path / "ca.json"
+        assert save_json_file(FakeModule(), str(target), {"authority": {"claims": {}}}) is None
+        assert json.loads(target.read_text(encoding="utf-8")) == {"authority": {"claims": {}}}
+
+    def test_an_existing_file_is_replaced(self, tmp_path):
+        target = tmp_path / "ca.json"
+        target.write_text('{"old": true}', encoding="utf-8")
+        save_json_file(FakeModule(), str(target), {"new": True})
+        assert json.loads(target.read_text(encoding="utf-8")) == {"new": True}
+
+    @pytest.mark.parametrize("failure", MOVE_FAILURES, ids=["oserror", "bare-exception"])
+    def test_a_failed_move_leaves_the_original_untouched(self, tmp_path, failure):
+        # The whole point: the previous implementation had already truncated
+        # the file by the time anything could go wrong.
+        target = tmp_path / "ca.json"
+        target.write_text('{"precious": true}', encoding="utf-8")
+
+        error = save_json_file(FakeModule(raises=failure), str(target), {"new": True})
+
+        assert "Failed to write JSON file" in error
+        assert json.loads(target.read_text(encoding="utf-8")) == {"precious": True}
+
+    @pytest.mark.parametrize("failure", MOVE_FAILURES, ids=["oserror", "bare-exception"])
+    def test_a_failed_move_leaves_no_temporary_file_behind(self, tmp_path, failure):
+        target = tmp_path / "ca.json"
+        target.write_text("{}", encoding="utf-8")
+        save_json_file(FakeModule(raises=failure), str(target), {"new": True})
+        assert [path.name for path in tmp_path.iterdir()] == ["ca.json"]
+
+    def test_a_fail_json_inside_the_move_still_cleans_up(self, tmp_path):
+        # Older cores call fail_json rather than raising, which is a SystemExit.
+        # It must keep propagating - fail_json has already emitted the result -
+        # but it must not leave a temporary file in the CA's config directory.
+        target = tmp_path / "ca.json"
+        target.write_text('{"precious": true}', encoding="utf-8")
+
+        with pytest.raises(SystemExit):
+            save_json_file(FakeModule(raises=SystemExit(1)), str(target), {"new": True})
+
+        assert [path.name for path in tmp_path.iterdir()] == ["ca.json"]
+        assert json.loads(target.read_text(encoding="utf-8")) == {"precious": True}
+
+    def test_a_symlink_is_followed_not_replaced(self, tmp_path):
+        # Replacing the link would leave whatever it pointed at holding stale
+        # configuration while the CA carried on reading that file.
+        real = tmp_path / "real-ca.json"
+        real.write_text('{"old": true}', encoding="utf-8")
+        link = tmp_path / "ca.json"
+        link.symlink_to(real)
+
+        assert save_json_file(FakeModule(), str(link), {"new": True}) is None
+
+        assert link.is_symlink()
+        assert json.loads(real.read_text(encoding="utf-8")) == {"new": True}
+
+    def test_unserialisable_data_is_reported_not_raised(self, tmp_path):
+        target = tmp_path / "ca.json"
+        target.write_text('{"precious": true}', encoding="utf-8")
+
+        error = save_json_file(FakeModule(), str(target), {"bad": object()})
+
+        assert "Failed to write JSON file" in error
+        assert json.loads(target.read_text(encoding="utf-8")) == {"precious": True}
+        assert [path.name for path in tmp_path.iterdir()] == ["ca.json"]
+
+    def test_the_temporary_file_shares_the_targets_directory(self, tmp_path):
+        # A rename is only atomic within one filesystem, so the temporary file
+        # cannot live in /tmp.
+        module = FakeModule()
+        target = tmp_path / "ca.json"
+        save_json_file(module, str(target), {})
+        source, destination = module.moves[0]
+        assert pathlib.Path(source).parent == tmp_path
+        assert destination == str(target)
+
+    def test_an_unwritable_directory_is_reported(self, tmp_path):
+        if os.geteuid() == 0:
+            pytest.skip("root ignores directory permissions")
+        unwritable = tmp_path / "readonly"
+        unwritable.mkdir()
+        unwritable.chmod(0o500)
+        try:
+            error = save_json_file(FakeModule(), str(unwritable / "ca.json"), {})
+        finally:
+            unwritable.chmod(0o700)
+        assert "Failed to write JSON file" in error

--- a/tests/unit/plugins/modules/test_configure.py
+++ b/tests/unit/plugins/modules/test_configure.py
@@ -9,6 +9,8 @@ These tests pin the comparison that stopped that.
 
 import json
 import os
+import pathlib
+import stat
 import subprocess
 import sys
 
@@ -22,9 +24,13 @@ from ansible_collections.matonb.step.plugins.modules.configure import (
     get_argument_spec,
 )
 
+# Options controlling how the file is located and written, rather than what
+# goes into it. Everything else must end up somewhere in the configuration.
+BEHAVIOUR_OPTIONS = {"backup", "create", "json_path"}
+
 # Sourced from the real spec so an option that stops being written shows up
 # here, rather than only in the constants the module happens to still list.
-NOTHING_REQUESTED = dict.fromkeys(set(get_argument_spec()) - {"json_path"})
+NOTHING_REQUESTED = dict.fromkeys(set(get_argument_spec()) - BEHAVIOUR_OPTIONS)
 
 
 def params(**requested):
@@ -40,7 +46,7 @@ class TestOptionCoverage:
         # Without this, deleting an entry from TOP_LEVEL_KEYS makes the module
         # silently stop writing that option while every other test still
         # passes: they all derive their parameters from those same constants.
-        assert set(get_argument_spec()) - {"json_path"} == set(TOP_LEVEL_KEYS) | set(CLAIM_KEYS)
+        assert set(get_argument_spec()) - BEHAVIOUR_OPTIONS == set(TOP_LEVEL_KEYS) | set(CLAIM_KEYS)
 
     def test_the_claim_names_are_the_ones_step_reads(self):
         # Asserted as literals, because everything else in this file takes the
@@ -183,6 +189,20 @@ def run_module(json_path, **requested):
     return json.loads(completed.stdout)
 
 
+def existing_config(tmp_path, claims=None, **contents):
+    """Write a ca.json directly and return its path.
+
+    Written rather than produced by running the module, so a write regression
+    cannot corrupt the fixture and the assertion at the same time.
+    """
+    config = dict(contents)
+    if claims:
+        config["authority"] = {"claims": claims}
+    config_file = tmp_path / "ca.json"
+    config_file.write_text(json.dumps(config), encoding="utf-8")
+    return config_file
+
+
 class TestReportedChangedState:
     """The module as Ansible actually invokes it.
 
@@ -208,8 +228,7 @@ class TestReportedChangedState:
     def test_a_no_op_run_leaves_the_file_byte_for_byte_alone(self, tmp_path):
         # Not just "changed is false" - the file must not be rewritten at all,
         # or anything watching its mtime sees churn.
-        config_file = tmp_path / "ca.json"
-        run_module(config_file, max_tls_cert_duration="8760h")
+        config_file = existing_config(tmp_path, claims={"maxTLSCertDuration": "8760h"})
         before = config_file.read_bytes()
         mtime = config_file.stat().st_mtime_ns
 
@@ -218,8 +237,7 @@ class TestReportedChangedState:
         assert config_file.stat().st_mtime_ns == mtime
 
     def test_a_changed_setting_is_reported_and_written(self, tmp_path):
-        config_file = tmp_path / "ca.json"
-        run_module(config_file, max_tls_cert_duration="8760h")
+        config_file = existing_config(tmp_path, claims={"maxTLSCertDuration": "8760h"})
 
         result = run_module(config_file, max_tls_cert_duration="17520h")
 
@@ -236,8 +254,7 @@ class TestReportedChangedState:
         assert json.loads(config_file.read_text(encoding="utf-8")) == {"address": ":443"}
 
     def test_check_mode_reports_no_change_when_already_correct(self, tmp_path):
-        config_file = tmp_path / "ca.json"
-        run_module(config_file, max_tls_cert_duration="8760h")
+        config_file = existing_config(tmp_path, claims={"maxTLSCertDuration": "8760h"})
 
         result = run_module(config_file, max_tls_cert_duration="8760h", _ansible_check_mode=True)
 
@@ -260,7 +277,7 @@ class TestReportedChangedState:
         assert config_file.read_bytes() == before
 
     def test_every_exit_carries_a_message(self, tmp_path):
-        config_file = tmp_path / "ca.json"
+        config_file = existing_config(tmp_path)
         changed = run_module(config_file, max_tls_cert_duration="8760h")
         unchanged = run_module(config_file, max_tls_cert_duration="8760h")
         predicted = run_module(config_file, max_tls_cert_duration="17520h", _ansible_check_mode=True)
@@ -286,7 +303,7 @@ class TestFailures:
         unwritable.mkdir()
         unwritable.chmod(0o500)
         try:
-            result = run_module(unwritable / "ca.json", max_tls_cert_duration="8760h")
+            result = run_module(unwritable / "ca.json", max_tls_cert_duration="8760h", create=True)
         finally:
             unwritable.chmod(0o700)
 
@@ -294,17 +311,166 @@ class TestFailures:
         assert "Failed to write JSON file" in result["msg"]
 
     def test_an_invalid_duration_names_the_option(self, tmp_path):
-        result = run_module(tmp_path / "ca.json", max_tls_cert_duration="forever")
+        result = run_module(existing_config(tmp_path), max_tls_cert_duration="forever")
 
         assert result["failed"] is True
         assert "max_tls_cert_duration" in result["msg"]
 
-    def test_requesting_nothing_against_a_missing_file_creates_nothing(self, tmp_path):
-        # Behaviour change: this used to write a file containing "{}", which was
-        # never a usable ca.json, and reported changed for doing so.
+    def test_a_file_that_is_not_a_json_object_is_refused(self, tmp_path):
+        # Reaches .update() otherwise, and surfaces as an AttributeError
+        # traceback rather than something an operator can act on.
+        config_file = tmp_path / "ca.json"
+        config_file.write_text('["an", "array"]', encoding="utf-8")
+
+        result = run_module(config_file, max_tls_cert_duration="8760h")
+
+        assert result["failed"] is True
+        assert "does not hold a JSON object" in result["msg"]
+
+
+class TestMissingFile:
+    """A path that is not there is a mistake until the task says otherwise.
+
+    Treating it as an empty configuration meant a mistyped json_path produced a
+    new, nearly empty file and reported success, while the CA it was meant to
+    configure was never touched (#37).
+    """
+
+    def test_a_missing_file_fails_and_creates_nothing(self, tmp_path):
         config_file = tmp_path / "ca.json"
 
-        result = run_module(config_file)
+        result = run_module(config_file, max_tls_cert_duration="8760h")
+
+        assert result["failed"] is True
+        assert "does not exist" in result["msg"]
+        assert "create" in result["msg"]
+        assert not config_file.exists()
+
+    def test_a_missing_file_with_nothing_requested_still_fails(self, tmp_path):
+        # The mistyped-path case is usually noticed on a run that changes
+        # nothing, so this must not quietly report ok either.
+        config_file = tmp_path / "ca.json"
+
+        assert run_module(config_file)["failed"] is True
+        assert not config_file.exists()
+
+    def test_create_writes_a_new_file(self, tmp_path):
+        config_file = tmp_path / "ca.json"
+
+        result = run_module(config_file, max_tls_cert_duration="8760h", create=True)
+
+        assert result["changed"] is True
+        assert json.loads(config_file.read_text(encoding="utf-8")) == {
+            "authority": {"claims": {"maxTLSCertDuration": "8760h"}}
+        }
+
+    def test_create_writes_nothing_in_check_mode(self, tmp_path):
+        config_file = tmp_path / "ca.json"
+
+        result = run_module(config_file, max_tls_cert_duration="8760h", create=True, _ansible_check_mode=True)
+
+        assert result["changed"] is True
+        assert not config_file.exists()
+
+
+class TestBackup:
+    def test_no_backup_is_taken_by_default(self, tmp_path):
+        config_file = existing_config(tmp_path)
+
+        result = run_module(config_file, max_tls_cert_duration="8760h")
+
+        assert "backup_file" not in result
+        assert [path.name for path in tmp_path.iterdir()] == ["ca.json"]
+
+    def test_backup_preserves_the_previous_contents(self, tmp_path):
+        config_file = existing_config(tmp_path, claims={"maxTLSCertDuration": "8760h"})
+        before = config_file.read_text(encoding="utf-8")
+
+        result = run_module(config_file, max_tls_cert_duration="17520h", backup=True)
+
+        assert pathlib.Path(result["backup_file"]).read_text(encoding="utf-8") == before
+        assert "17520h" in config_file.read_text(encoding="utf-8")
+
+    def test_no_backup_when_nothing_changes(self, tmp_path):
+        # A backup per run would litter the CA directory with copies of a file
+        # that never changed.
+        config_file = existing_config(tmp_path, claims={"maxTLSCertDuration": "8760h"})
+
+        result = run_module(config_file, max_tls_cert_duration="8760h", backup=True)
 
         assert result["changed"] is False
-        assert not config_file.exists()
+        assert "backup_file" not in result
+        assert [path.name for path in tmp_path.iterdir()] == ["ca.json"]
+
+    def test_no_backup_in_check_mode(self, tmp_path):
+        config_file = existing_config(tmp_path)
+
+        run_module(config_file, max_tls_cert_duration="8760h", backup=True, _ansible_check_mode=True)
+
+        assert [path.name for path in tmp_path.iterdir()] == ["ca.json"]
+
+
+class TestPathHandling:
+    def test_a_tilde_in_json_path_is_expanded(self, tmp_path, monkeypatch):
+        # json_path used to be type: str, so `~` stayed literal while ca_path
+        # and ca_config beside it expanded - and the missing file was then
+        # created, producing a directory named `~`.
+        monkeypatch.setenv("HOME", str(tmp_path))
+        (tmp_path / "step").mkdir()
+        expanded = tmp_path / "step" / "ca.json"
+        expanded.write_text("{}", encoding="utf-8")
+
+        result = run_module("~/step/ca.json", max_tls_cert_duration="8760h")
+
+        assert result["changed"] is True
+        assert "8760h" in expanded.read_text(encoding="utf-8")
+        assert not (tmp_path / "~").exists()
+
+
+class TestFilePreservation:
+    """Attributes of the file being replaced, against the real atomic_move.
+
+    The FakeModule in test_utils uses shutil.move, which models neither
+    copystat nor chown, so nothing there would notice atomic_move being called
+    with keep_dest_attrs=False. Losing the mode is how step-ca ends up locked
+    out of its own configuration.
+    """
+
+    def test_the_existing_mode_survives_the_write(self, tmp_path):
+        config_file = existing_config(tmp_path)
+        config_file.chmod(0o640)
+
+        assert run_module(config_file, max_tls_cert_duration="8760h")["changed"] is True
+        assert stat.S_IMODE(config_file.stat().st_mode) == 0o640
+
+    def test_a_symlink_is_followed_not_replaced(self, tmp_path):
+        # Replacing the link would leave the file it named holding stale
+        # configuration while the CA carried on reading it.
+        real = tmp_path / "real-ca.json"
+        real.write_text("{}", encoding="utf-8")
+        link = tmp_path / "ca.json"
+        link.symlink_to(real)
+
+        assert run_module(link, max_tls_cert_duration="8760h")["changed"] is True
+
+        assert link.is_symlink()
+        assert "8760h" in real.read_text(encoding="utf-8")
+
+    def test_no_temporary_file_is_left_beside_the_target(self, tmp_path):
+        config_file = existing_config(tmp_path)
+        run_module(config_file, max_tls_cert_duration="8760h")
+        assert sorted(path.name for path in tmp_path.iterdir()) == ["ca.json"]
+
+
+class TestMalformedAuthority:
+    @pytest.mark.parametrize("authority", ["null", '"text"', "3", "[]"], ids=["null", "string", "int", "array"])
+    def test_an_authority_that_is_not_an_object_is_refused(self, tmp_path, authority):
+        # Reaches setdefault() otherwise, and surfaces as an AttributeError
+        # traceback rather than something an operator can act on.
+        config_file = tmp_path / "ca.json"
+        config_file.write_text(f'{{"authority": {authority}}}', encoding="utf-8")
+
+        result = run_module(config_file, max_tls_cert_duration="8760h")
+
+        assert result["failed"] is True
+        assert "'authority' entry" in result["msg"]


### PR DESCRIPTION
Closes #37. Closes #42.

Done together because #42's own body says they are one change: the atomic write
belongs in the shared helper, so any future caller inherits it rather than
repeating the mistake.

## The write could destroy ca.json (#37)

`save_json_file` opened the target with `"w"`, emptying it before the new
contents existed. An interruption, a full disk, or a serialisation error left a
`ca.json` step-ca cannot load, with no `backup` option to restore from.

It also treated a missing file as an empty one, so a mistyped `json_path`
produced a new, nearly empty configuration and reported success while the real CA
went untouched:

```
$ ... json_path=/tmp/typo.json max_tls_cert_duration=8760h
{"changed": true, "msg": "JSON file updated", ...}
```

Compounded by `json_path` being typed `str` while `ca_config` and `ca_path`
beside it were `path` — `~` stayed literal, and the module then created a
directory called `~`.

### Now

The write serialises to a temporary file in the **target's own directory** (a
rename is only atomic within one filesystem), fsyncs it, and hands it to
`AnsibleModule.atomic_move`, which preserves an existing destination's mode,
ownership and SELinux context. Whatever fails, the original is still there.

`json_path` must exist unless `create: true`, and is now `type: path`.
`backup: true` keeps a timestamped copy and returns `backup_file`.

## Two bugs found in review, not in the original issue

**`atomic_move` does not raise `OSError`.** Current ansible-core raises a bare
`Exception`; older cores `fail_json` inside it, which is a `SystemExit`. Catching
only `OSError` left a `.matonb-step-*.json` beside `ca.json` and produced **no
JSON result at all** — losing the error message and the `backup_file` plumbing.

This is reachable in ordinary use: **a bind-mounted `ca.json` gives `EBUSY` on
rename**, which is how this collection's own integration suite runs. Cleanup is
now a `finally`, so it runs for `SystemExit` too while letting that propagate.

**`backup_local` raises as well**, and was unwrapped — `backup: true` against an
unwritable directory reported `MODULE FAILURE` with a traceback rather than a
message.

Also from review: a symlinked `json_path` is followed rather than replaced
(matching 1.1.3 and `ansible.builtin.copy`'s default), the `authority` block is
type-checked as well as the top level, and the docs no longer imply crash-safety
the implementation did not have — hence the `fsync`.

## Shared helpers (#42)

`configure.py`'s private `load_json_file`/`save_json_file` are gone. The
`module_utils` `save_json_file` had **no callers at all** — the version in use
was the untested copy. Errors now follow the `(value, error)` convention the rest
of `module_utils` uses, so `if "error" in json_data` is gone with it.

## Verification

| | |
| --- | --- |
| `pytest tests/unit -q` | 296 passed (was 269) |
| `ansible-test sanity` | clean |
| `ansible-test units` | 128 + 168 = 296 passed |
| `pre-commit run --all-files` | clean |
| `tests/integration/run.sh` | both modes pass |

Mutation-tested — each fails tests:

| Reintroduced defect | Failed |
| --- | --- |
| Truncate-in-place write | 5 |
| `keep_dest_attrs=False` (destination loses its mode) | 6 |
| Catching only `OSError` around the move | 3 |
| Symlink replaced rather than followed | 2 |
| `create` defaulting to true | 2 |
| Backup never taken | 1 |
| `json_path` back to `type: str` | 1 |
| `authority` guard removed | 4 |

The `keep_dest_attrs` one passed the entire suite until a test was added against
the real `atomic_move` — its failure mode is `ca.json` losing its mode and
locking step-ca out of its own configuration.

## Behaviour changes

Both in the README's upgrade section:

- A missing `json_path` fails rather than creating a file. `create: true`
  restores the old behaviour.
- `json_path` expands `~`.

## Version

`feat`, not `fix`: `ansible-test sanity` rejects `version_added` on a patch
release, so new options require a minor. This is 1.2.0.
