### PR TITLE
Cover process.py, and fix the privilege drop it exposed

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,12 @@ jobs:
   # tree, so both jobs check out into one.
   sanity:
     name: Sanity
-    runs-on: ubuntu-latest
+    # Pinned rather than latest because the shellcheck sanity test uses
+    # whichever shellcheck the runner ships - 0.9.0 on 24.04 - and
+    # .pre-commit-config.yaml pins the same one so a local pass means what a
+    # CI pass means. On ubuntu-latest the pair silently diverges the day the
+    # label moves; here the two are updated together, deliberately.
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout into a collection path

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,15 +31,19 @@ repos:
   # CI runs shellcheck as part of ansible-test sanity, on a runner that has it;
   # a workstation without it saw that test skipped and the gate pass anyway.
   # This closes the gap the other way round, so the two agree before a push.
+  #
+  # Pinned to shellcheck 0.9.0, which is what ubuntu-latest ships (24.04 has
+  # 0.9.0-1) and therefore what the sanity test actually runs. Version matters:
+  # 0.11 stopped reporting SC2015 where the alternative branch is `true` or
+  # exits, so a hook on 0.11 passed two findings straight through to a red CI.
+  # If this drifts from the runner image again, that is the thing to re-check.
   - repo: https://github.com/shellcheck-py/shellcheck-py
-    rev: v0.11.0.1
+    rev: v0.9.0.6
     hooks:
       - id: shellcheck
         name: shellcheck
         description: Lint shell scripts
-        # The same exclusions ansible-test passes, so this hook and the sanity
-        # test disagree about nothing except their shellcheck version - which
-        # they still can, so code here is written to satisfy the older one too.
+        # The exclusions ansible-test passes, so nothing separates the two.
         args: [-e, "SC1090,SC1091,SC2028"]
 #
 # Disabled for now - requires more complex configuration for collection metadata

--- a/plugins/module_utils/process.py
+++ b/plugins/module_utils/process.py
@@ -68,14 +68,22 @@ def sanitize_output(text: Optional[str], strip_ansi: bool = True) -> Optional[st
     return text
 
 
-def demote_user(username: str):
-    """Demote the current process to the specified user's privileges.
+def _resolve_demotion(username: str) -> tuple[pwd.struct_passwd, list[int]]:
+    """Look up everything the switch needs, before any fork.
+
+    Both lookups go to NSS, which on a host using SSSD or LDAP means network
+    I/O and a lock. Done here, in the parent, that is ordinary. Done between
+    fork and exec it is the classic preexec_fn hazard: the child holds a copy
+    of whatever locks were held at fork time and can deadlock against them.
 
     Args:
         username: The target system user to impersonate.
 
+    Returns:
+        The user's passwd record and the group ids they belong to.
+
     Raises:
-        RuntimeError: If the user cannot be found or privileges cannot be dropped.
+        RuntimeError: If the user cannot be found or their groups cannot be read.
     """
     try:
         pw_record = pwd.getpwnam(username)
@@ -83,14 +91,33 @@ def demote_user(username: str):
         raise RuntimeError(f"User '{username}' not found on the system.") from exc
 
     try:
+        groups = os.getgrouplist(username, pw_record.pw_gid)
+    except OSError as exc:
+        raise RuntimeError(f"Could not read the groups for user '{username}': {exc}") from exc
+
+    return pw_record, groups
+
+
+def _apply_demotion(username: str, pw_record: pwd.struct_passwd, groups: list[int]) -> None:
+    """Drop to the given user's ids. Syscalls only, safe after a fork.
+
+    Args:
+        username: The target system user, for the environment and messages.
+        pw_record: The user's passwd record, from _resolve_demotion.
+        groups: The user's group ids, from _resolve_demotion.
+
+    Raises:
+        RuntimeError: If privileges cannot be dropped.
+    """
+    try:
         # Supplementary groups first. setgid and setuid leave the calling
         # process's own group memberships in place, and the caller here is
         # root, so without this the command keeps root's groups after the
         # switch and holds access the target user was never granted.
         #
-        # Then GID, then UID. Once the UID is no longer root neither of the
-        # first two is permitted, so this order is what makes the drop stick.
-        os.initgroups(username, pw_record.pw_gid)
+        # Then GID, then UID. Once the UID is no longer root none of the three
+        # is permitted, so this order is what makes the drop stick.
+        os.setgroups(groups)
         os.setgid(pw_record.pw_gid)
         os.setuid(pw_record.pw_uid)
     except OSError as exc:
@@ -106,6 +133,19 @@ def demote_user(username: str):
     )
 
 
+def demote_user(username: str):
+    """Demote the current process to the specified user's privileges.
+
+    Args:
+        username: The target system user to impersonate.
+
+    Raises:
+        RuntimeError: If the user cannot be found or privileges cannot be dropped.
+    """
+    pw_record, groups = _resolve_demotion(username)
+    _apply_demotion(username, pw_record, groups)
+
+
 def _demotion_hook(username: Optional[str]) -> Optional[Callable[[], None]]:
     """Build the post-fork hook that drops privileges, or nothing to run.
 
@@ -113,17 +153,28 @@ def _demotion_hook(username: Optional[str]) -> Optional[Callable[[], None]]:
     runs arbitrary Python between fork and exec and is not thread-safe, so a
     command with no user to switch to should not carry one at all.
 
+    The lookup happens here rather than in the hook. subprocess reports any
+    exception from a preexec_fn as a generic SubprocessError - "Exception
+    occurred in preexec_fn." - so a misspelled username raised in the child
+    reaches the operator as that and nothing else. Raised here it is the
+    RuntimeError naming the user, before anything forks.
+
     Args:
         username: The target system user, or None to run as the current user.
 
     Returns:
         A callable for subprocess's preexec_fn, or None when nothing is to be
         demoted.
+
+    Raises:
+        RuntimeError: If the user cannot be found or their groups cannot be read.
     """
     if not username:
         return None
 
-    return lambda: demote_user(username)
+    pw_record, groups = _resolve_demotion(username)
+
+    return lambda: _apply_demotion(username, pw_record, groups)
 
 
 def _validate_user_switch(username: Optional[str]) -> None:

--- a/plugins/module_utils/process.py
+++ b/plugins/module_utils/process.py
@@ -106,6 +106,26 @@ def demote_user(username: str):
     )
 
 
+def _demotion_hook(username: Optional[str]) -> Optional[Callable[[], None]]:
+    """Build the post-fork hook that drops privileges, or nothing to run.
+
+    Returning None rather than a callable that does nothing matters: preexec_fn
+    runs arbitrary Python between fork and exec and is not thread-safe, so a
+    command with no user to switch to should not carry one at all.
+
+    Args:
+        username: The target system user, or None to run as the current user.
+
+    Returns:
+        A callable for subprocess's preexec_fn, or None when nothing is to be
+        demoted.
+    """
+    if not username:
+        return None
+
+    return lambda: demote_user(username)
+
+
 def _validate_user_switch(username: Optional[str]) -> None:
     """Validate that we can switch to the specified user.
 
@@ -242,7 +262,7 @@ def run_command(
         env=user_env,
         text=text,
         shell=shell,
-        preexec_fn=lambda: demote_user(username) if username else None,
+        preexec_fn=_demotion_hook(username),
     ) as process:
         # Wait for the process to complete
         stdout, stderr = process.communicate()
@@ -293,7 +313,7 @@ def _run_with_timeout(
         stderr=subprocess.PIPE,
         env=env,
         text=text,
-        preexec_fn=lambda: demote_user(username) if username else None,
+        preexec_fn=_demotion_hook(username),
     )
 
     try:

--- a/plugins/module_utils/process.py
+++ b/plugins/module_utils/process.py
@@ -83,7 +83,14 @@ def demote_user(username: str):
         raise RuntimeError(f"User '{username}' not found on the system.") from exc
 
     try:
-        # First change GID, then UID to prevent permission issues
+        # Supplementary groups first. setgid and setuid leave the calling
+        # process's own group memberships in place, and the caller here is
+        # root, so without this the command keeps root's groups after the
+        # switch and holds access the target user was never granted.
+        #
+        # Then GID, then UID. Once the UID is no longer root neither of the
+        # first two is permitted, so this order is what makes the drop stick.
+        os.initgroups(username, pw_record.pw_gid)
         os.setgid(pw_record.pw_gid)
         os.setuid(pw_record.pw_uid)
     except OSError as exc:

--- a/plugins/module_utils/process.py
+++ b/plugins/module_utils/process.py
@@ -344,17 +344,17 @@ def _run_with_timeout(
         return result
 
     finally:
-        # A no-op on every path above: communicate() has set returncode by the
-        # time we arrive, and terminate() skips a process already known to have
-        # died. It earns its place for the paths *not* above - communicate()
-        # raising something other than TimeoutExpired, where the child is still
-        # running and would otherwise be left behind. ProcessLookupError covers
-        # it exiting between that failure and this call, which is why the
-        # handler stays even though the tests cannot reach it.
-        try:
-            process.terminate()
-        except ProcessLookupError:
-            pass
+        # A no-op on every path above, where communicate() has already set
+        # returncode and terminate() skips a process known to have died. It
+        # earns its place for the paths not above: communicate() raising
+        # anything other than TimeoutExpired - a UnicodeDecodeError on invalid
+        # UTF-8 from the child, with text=True - leaves that child running and
+        # this is what reaps it.
+        #
+        # No handler around it. Popen.send_signal polls first, returns early
+        # once returncode is set, and catches ProcessLookupError itself for the
+        # race after that (bpo-40550), so there is nothing left here to catch.
+        process.terminate()
 
 
 # For backward compatibility

--- a/plugins/module_utils/process.py
+++ b/plugins/module_utils/process.py
@@ -344,7 +344,13 @@ def _run_with_timeout(
         return result
 
     finally:
-        # Ensure the process is terminated
+        # A no-op on every path above: communicate() has set returncode by the
+        # time we arrive, and terminate() skips a process already known to have
+        # died. It earns its place for the paths *not* above - communicate()
+        # raising something other than TimeoutExpired, where the child is still
+        # running and would otherwise be left behind. ProcessLookupError covers
+        # it exiting between that failure and this call, which is why the
+        # handler stays even though the tests cannot reach it.
         try:
             process.terminate()
         except ProcessLookupError:

--- a/plugins/module_utils/process.py
+++ b/plugins/module_utils/process.py
@@ -235,44 +235,25 @@ def run_command(
         )
 
     # Otherwise, use the simpler subprocess approach
-    try:
-        # Use subprocess.Popen for more controlled execution
-        with subprocess.Popen(
-            command,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            env=user_env,
-            text=text,
-            shell=shell,
-            preexec_fn=lambda: demote_user(username) if username else None,
-        ) as process:
-            # Wait for the process to complete
-            stdout, stderr = process.communicate()
+    with subprocess.Popen(
+        command,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        env=user_env,
+        text=text,
+        shell=shell,
+        preexec_fn=lambda: demote_user(username) if username else None,
+    ) as process:
+        # Wait for the process to complete
+        stdout, stderr = process.communicate()
 
-            # Create CompletedProcess with results
-            result = _create_completed_process(command, process.returncode, stdout, stderr, text, strip_ansi)
+        # Create CompletedProcess with results
+        result = _create_completed_process(command, process.returncode, stdout, stderr, text, strip_ansi)
 
-            # Check return code if required
-            _handle_command_failure(result, check, text)
+        # Check return code if required
+        _handle_command_failure(result, check, text)
 
-            return result
-
-    except subprocess.CalledProcessError as exc:
-        if check:
-            # Sanitize stdout and stderr
-            stderr = sanitize_output(exc.stderr, strip_ansi) if text else exc.stderr
-            stdout = sanitize_output(exc.stdout, strip_ansi) if text else exc.stdout
-
-            raise RuntimeError(
-                f"Command failed with return code {exc.returncode}.\nSTDOUT: {stdout}\nSTDERR: {stderr}"
-            ) from exc
-
-        # Sanitize stdout and stderr for the exception case
-        if text:
-            exc.stdout = sanitize_output(exc.stdout, strip_ansi)
-            exc.stderr = sanitize_output(exc.stderr, strip_ansi)
-
-        return exc
+        return result
 
 
 def _run_with_timeout(
@@ -302,7 +283,7 @@ def _run_with_timeout(
 
     Raises:
         CommandTimeoutError: If the command execution exceeds the timeout.
-        subprocess.CalledProcessError: If the command returns non-zero and check=True.
+        RuntimeError: If the command returns non-zero and check=True.
     """
     # Start the process
     process = subprocess.Popen(

--- a/tests/unit/plugins/module_utils/test_process.py
+++ b/tests/unit/plugins/module_utils/test_process.py
@@ -1,0 +1,115 @@
+# Copyright: (c) 2025, Brett Maton <matonb@users.noreply.github.com>
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+"""Tests for command execution, privilege dropping and the timeout path."""
+
+import os
+import pwd
+
+import pytest
+
+from ansible_collections.matonb.step.plugins.module_utils.process import (
+    demote_user,
+)
+
+
+class FakePasswd:
+    """The subset of pwd.struct_passwd that demote_user reads."""
+
+    def __init__(self, uid=1234, gid=5678, directory="/home/stepuser"):
+        """Build a passwd record with the fields demote_user reads.
+
+        Args:
+            uid: The target user's uid.
+            gid: The target user's primary gid.
+            directory: The target user's home directory.
+        """
+        self.pw_uid = uid
+        self.pw_gid = gid
+        self.pw_dir = directory
+
+
+@pytest.fixture
+def recorded_switch(monkeypatch):
+    """Record the privilege calls demote_user makes, without making them.
+
+    Actually switching user needs root and is irreversible within the process,
+    so the calls are recorded instead. What matters here is which ones are made
+    and in what order, and that survives the substitution.
+
+    Returns:
+        list: (name, args) in the order demote_user called them.
+    """
+    calls = []
+
+    monkeypatch.setattr(pwd, "getpwnam", lambda _name: FakePasswd())
+    monkeypatch.setattr(os, "initgroups", lambda *args: calls.append(("initgroups", args)), raising=False)
+    monkeypatch.setattr(os, "setgid", lambda *args: calls.append(("setgid", args)))
+    monkeypatch.setattr(os, "setuid", lambda *args: calls.append(("setuid", args)))
+    monkeypatch.setattr(os, "environ", {})
+
+    return calls
+
+
+class TestDemoteUser:
+    def test_supplementary_groups_are_dropped(self, recorded_switch):
+        # setgid and setuid leave the supplementary groups of the *calling*
+        # process in place. Started as root - which is the only way this code
+        # runs at all - the child would keep root's group memberships after the
+        # switch, holding access the target user does not have. Dropping them
+        # is what makes this a privilege drop rather than a uid change.
+        demote_user("stepuser")
+
+        assert "initgroups" in [name for name, _ in recorded_switch]
+
+    def test_privileges_are_dropped_in_a_workable_order(self, recorded_switch):
+        # Order is the whole game: setuid last, because once the uid is no
+        # longer root neither initgroups nor setgid is permitted, and the
+        # process would be left holding what it meant to drop.
+        demote_user("stepuser")
+
+        assert [name for name, _ in recorded_switch] == ["initgroups", "setgid", "setuid"]
+
+    def test_the_target_users_own_ids_are_used(self, recorded_switch):
+        demote_user("stepuser")
+
+        by_name = dict(recorded_switch)
+        assert by_name["initgroups"] == ("stepuser", 5678)
+        assert by_name["setgid"] == (5678,)
+        assert by_name["setuid"] == (1234,)
+
+    def test_an_unknown_user_is_reported_by_name(self, monkeypatch):
+        def raise_key_error(name):
+            raise KeyError(name)
+
+        monkeypatch.setattr(pwd, "getpwnam", raise_key_error)
+
+        with pytest.raises(RuntimeError, match="nosuchuser"):
+            demote_user("nosuchuser")
+
+    def test_a_refused_switch_is_reported_by_name(self, monkeypatch):
+        # The realistic cause is running without root, where setgid is denied.
+        # The OSError alone says "Operation not permitted" and names no user.
+        monkeypatch.setattr(pwd, "getpwnam", lambda _name: FakePasswd())
+        monkeypatch.setattr(os, "initgroups", lambda *_args: None, raising=False)
+
+        def deny(*_args):
+            raise OSError(1, "Operation not permitted")
+
+        monkeypatch.setattr(os, "setgid", deny)
+
+        with pytest.raises(RuntimeError, match="stepuser"):
+            demote_user("stepuser")
+
+    def test_the_environment_describes_the_new_user(self, recorded_switch, monkeypatch):
+        environment = {}
+        monkeypatch.setattr(os, "environ", environment)
+
+        demote_user("stepuser")
+
+        # step reads HOME to find its own configuration; left pointing at
+        # root's, a demoted command would read the wrong CA.
+        assert environment == {
+            "HOME": "/home/stepuser",
+            "USER": "stepuser",
+            "LOGNAME": "stepuser",
+        }

--- a/tests/unit/plugins/module_utils/test_process.py
+++ b/tests/unit/plugins/module_utils/test_process.py
@@ -4,11 +4,21 @@
 
 import os
 import pwd
+import subprocess
+import time
 
 import pytest
 
 from ansible_collections.matonb.step.plugins.module_utils.process import (
+    CommandTimeoutError,
+    _create_completed_process,
+    _demotion_hook,
+    _handle_command_failure,
+    _validate_user_switch,
     demote_user,
+    run_command,
+    sanitize_output,
+    strip_ansi_sequences,
 )
 
 
@@ -59,7 +69,7 @@ class TestDemoteUser:
         # is what makes this a privilege drop rather than a uid change.
         demote_user("stepuser")
 
-        assert "initgroups" in [name for name, _ in recorded_switch]
+        assert "initgroups" in [name for name, arguments in recorded_switch]
 
     def test_privileges_are_dropped_in_a_workable_order(self, recorded_switch):
         # Order is the whole game: setuid last, because once the uid is no
@@ -67,7 +77,7 @@ class TestDemoteUser:
         # process would be left holding what it meant to drop.
         demote_user("stepuser")
 
-        assert [name for name, _ in recorded_switch] == ["initgroups", "setgid", "setuid"]
+        assert [name for name, arguments in recorded_switch] == ["initgroups", "setgid", "setuid"]
 
     def test_the_target_users_own_ids_are_used(self, recorded_switch):
         demote_user("stepuser")
@@ -113,3 +123,201 @@ class TestDemoteUser:
             "USER": "stepuser",
             "LOGNAME": "stepuser",
         }
+
+
+class TestSanitizeOutput:
+    def test_colour_codes_are_removed(self):
+        # step colours its output when it thinks it has a terminal. Those bytes
+        # end up in module results and in the diffs modules compare, where an
+        # escape sequence reads as a difference that is not one.
+        assert strip_ansi_sequences("\x1b[32mok\x1b[0m") == "ok"
+
+    def test_control_characters_are_dropped_but_layout_is_kept(self):
+        # A bare \x07 in a module's JSON result is not printable and not useful;
+        # newlines and tabs are how step formats output worth reading.
+        assert sanitize_output("a\x07b\nc\td") == "ab\nc\td"
+
+    def test_none_survives_as_none(self):
+        # stdout is None when the stream was not captured, which is not an
+        # error and must not become the string "None".
+        assert sanitize_output(None) is None
+
+    def test_strip_ansi_false_still_does_not_preserve_colour(self):
+        # Worth pinning because the name promises otherwise. Skipping the ANSI
+        # regex does not keep the sequence: ESC is not printable, so the filter
+        # below removes it and leaves the rest as literal text. The option
+        # buys mangled output rather than coloured output, and a caller
+        # reaching for it to keep colour will not get it.
+        assert sanitize_output("\x1b[32mok\x1b[0m", strip_ansi=False) == "[32mok[0m"
+
+
+class TestDemotionHook:
+    def test_no_username_means_no_hook_at_all(self):
+        # Not a callable that returns None: subprocess runs whatever it is
+        # given between fork and exec, and there is nothing to do here.
+        assert _demotion_hook(None) is None
+        assert _demotion_hook("") is None
+
+    def test_a_username_produces_a_hook_that_demotes_to_it(self, monkeypatch):
+        demoted = []
+        monkeypatch.setattr(
+            "ansible_collections.matonb.step.plugins.module_utils.process.demote_user",
+            demoted.append,
+        )
+
+        hook = _demotion_hook("stepuser")
+        hook()
+
+        assert demoted == ["stepuser"]
+
+
+class TestValidateUserSwitch:
+    def test_a_switch_without_root_is_refused_with_advice(self, monkeypatch):
+        # The failure would otherwise happen after the fork, where it surfaces
+        # as an opaque subprocess error rather than as "you need become: true".
+        monkeypatch.setattr(os, "geteuid", lambda: 1000)
+
+        with pytest.raises(RuntimeError, match="become: true"):
+            _validate_user_switch("stepuser")
+
+    def test_root_may_switch(self, monkeypatch):
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+
+        assert _validate_user_switch("stepuser") is None
+
+    def test_no_switch_is_requested_so_privileges_do_not_matter(self, monkeypatch):
+        monkeypatch.setattr(os, "geteuid", lambda: 1000)
+
+        assert _validate_user_switch(None) is None
+
+
+class TestCompletedProcess:
+    def test_output_is_sanitized_when_captured_as_text(self):
+        result = _create_completed_process(["step"], 0, "\x1b[32mok\x1b[0m", None, text=True, strip_ansi=True)
+
+        assert result.stdout == "ok"
+
+    def test_bytes_are_left_alone(self):
+        # sanitize_output works on str. Handing it bytes would raise, so the
+        # text flag has to gate it rather than merely describe it.
+        result = _create_completed_process(["step"], 0, b"\x1b[32mok", None, text=False, strip_ansi=True)
+
+        assert result.stdout == b"\x1b[32mok"
+
+
+class TestHandleCommandFailure:
+    def test_a_failure_reports_both_streams(self):
+        # Whichever stream step used, the operator needs it: the message is all
+        # they see when a module fails.
+        result = subprocess.CompletedProcess(args=["step"], returncode=2, stdout="out", stderr="boom")
+
+        with pytest.raises(RuntimeError, match="boom") as failure:
+            _handle_command_failure(result, check=True, text=True)
+
+        assert "out" in str(failure.value)
+        assert "2" in str(failure.value)
+
+    def test_check_false_lets_a_failure_through(self):
+        result = subprocess.CompletedProcess(args=["step"], returncode=2, stdout="", stderr="")
+
+        assert _handle_command_failure(result, check=False, text=True) is None
+
+    def test_success_is_never_a_failure(self):
+        result = subprocess.CompletedProcess(args=["step"], returncode=0, stdout="", stderr="")
+
+        assert _handle_command_failure(result, check=True, text=True) is None
+
+
+class TestRunCommand:
+    def test_a_successful_command_returns_its_output(self):
+        result = run_command(["echo", "hello"])
+
+        assert result.returncode == 0
+        assert result.stdout.strip() == "hello"
+
+    def test_a_failure_raises_by_default(self):
+        with pytest.raises(RuntimeError, match="return code 1"):
+            run_command(["false"])
+
+    def test_check_false_returns_the_failure_instead(self):
+        result = run_command(["false"], check=False)
+
+        assert result.returncode == 1
+
+    def test_extra_environment_reaches_the_command(self):
+        # step is configured through the environment - STEPPATH above all - so
+        # a variable that does not arrive means a command reading the wrong CA.
+        result = run_command(["sh", "-c", "echo $STEP_TEST_MARKER"], env_vars={"STEP_TEST_MARKER": "arrived"})
+
+        assert result.stdout.strip() == "arrived"
+
+    def test_the_inherited_environment_survives_alongside_it(self, monkeypatch):
+        monkeypatch.setenv("STEP_TEST_INHERITED", "kept")
+
+        result = run_command(["sh", "-c", "echo $STEP_TEST_INHERITED"], env_vars={"STEP_TEST_OTHER": "x"})
+
+        assert result.stdout.strip() == "kept"
+
+    def test_the_command_is_logged_before_it_runs(self):
+        # Modules pass module.log here. Writing to stdout instead would corrupt
+        # the JSON Ansible parses, so this exists and is worth keeping honest.
+        logged = []
+
+        run_command(["echo", "hello"], logger=logged.append)
+
+        assert logged == ["Executing command: echo hello"]
+
+    def test_a_shell_command_runs_through_the_shell(self):
+        # The shell is the subject here, not an oversight.
+        result = run_command("echo one && echo two", shell=True)  # noqa: S604
+
+        assert result.stdout.split() == ["one", "two"]
+
+    def test_output_can_be_left_as_bytes(self):
+        result = run_command(["echo", "hello"], text=False)
+
+        assert result.stdout.strip() == b"hello"
+
+    def test_demotion_without_root_is_refused_before_forking(self):
+        # Runs as an ordinary user, which is the whole point: the refusal has
+        # to come from _validate_user_switch rather than from the child.
+        if os.geteuid() == 0:
+            pytest.skip("running as root, so the switch would be permitted")
+
+        with pytest.raises(RuntimeError, match="requires root privileges"):
+            run_command(["echo", "hello"], username="stepuser")
+
+
+class TestRunWithTimeout:
+    def test_a_command_within_its_timeout_is_unaffected(self):
+        result = run_command(["echo", "hello"], timeout=10)
+
+        assert result.stdout.strip() == "hello"
+
+    def test_an_overrunning_command_times_out(self):
+        # The provisioner module's whole anti-hang design rests on this: step
+        # prompting for input that never comes must become a failed task rather
+        # than a play that waits forever.
+        with pytest.raises(CommandTimeoutError, match="timed out after"):
+            run_command(["sleep", "5"], timeout=0.2)
+
+    def test_the_timed_out_command_is_actually_killed(self, tmp_path):
+        # Raising while leaving the process running would satisfy the test
+        # above and still leak a step process holding the CA's files open.
+        # The marker is written only if the command survived its timeout.
+        marker = tmp_path / "survived"
+
+        with pytest.raises(CommandTimeoutError):
+            run_command(["sh", "-c", f"sleep 1; touch {marker}"], timeout=0.2)
+
+        time.sleep(1.5)
+        assert not marker.exists()
+
+    def test_a_failure_inside_the_timeout_still_reports_normally(self):
+        with pytest.raises(RuntimeError, match="return code 1"):
+            run_command(["false"], timeout=10)
+
+    def test_check_false_applies_under_a_timeout_too(self):
+        result = run_command(["false"], timeout=10, check=False)
+
+        assert result.returncode == 1

--- a/tests/unit/plugins/module_utils/test_process.py
+++ b/tests/unit/plugins/module_utils/test_process.py
@@ -114,6 +114,18 @@ class TestDemoteUser:
         with pytest.raises(RuntimeError, match="stepuser"):
             demote_user("stepuser")
 
+    def test_unreadable_groups_are_reported_by_name(self, recorded_switch, monkeypatch):
+        # getgrouplist goes to NSS, so on a host backed by SSSD or LDAP this is
+        # a network call and can fail on its own. Without a message naming the
+        # user it surfaces as a bare errno from inside a privilege drop.
+        def deny(*_args):
+            raise OSError(5, "Input/output error")
+
+        monkeypatch.setattr(os, "getgrouplist", deny)
+
+        with pytest.raises(RuntimeError, match="groups for user 'stepuser'"):
+            demote_user("stepuser")
+
     def test_the_environment_describes_the_new_user(self, recorded_switch, monkeypatch):
         environment = {}
         monkeypatch.setattr(os, "environ", environment)

--- a/tests/unit/plugins/module_utils/test_process.py
+++ b/tests/unit/plugins/module_utils/test_process.py
@@ -4,8 +4,8 @@
 
 import os
 import pwd
+import signal
 import subprocess
-import time
 
 import pytest
 
@@ -52,7 +52,8 @@ def recorded_switch(monkeypatch):
     calls = []
 
     monkeypatch.setattr(pwd, "getpwnam", lambda _name: FakePasswd())
-    monkeypatch.setattr(os, "initgroups", lambda *args: calls.append(("initgroups", args)), raising=False)
+    monkeypatch.setattr(os, "getgrouplist", lambda *_args: [5678, 27])
+    monkeypatch.setattr(os, "setgroups", lambda *args: calls.append(("setgroups", args)))
     monkeypatch.setattr(os, "setgid", lambda *args: calls.append(("setgid", args)))
     monkeypatch.setattr(os, "setuid", lambda *args: calls.append(("setuid", args)))
     monkeypatch.setattr(os, "environ", {})
@@ -69,21 +70,21 @@ class TestDemoteUser:
         # is what makes this a privilege drop rather than a uid change.
         demote_user("stepuser")
 
-        assert "initgroups" in [name for name, arguments in recorded_switch]
+        assert "setgroups" in [name for name, arguments in recorded_switch]
 
     def test_privileges_are_dropped_in_a_workable_order(self, recorded_switch):
         # Order is the whole game: setuid last, because once the uid is no
-        # longer root neither initgroups nor setgid is permitted, and the
+        # longer root neither setgroups nor setgid is permitted, and the
         # process would be left holding what it meant to drop.
         demote_user("stepuser")
 
-        assert [name for name, arguments in recorded_switch] == ["initgroups", "setgid", "setuid"]
+        assert [name for name, arguments in recorded_switch] == ["setgroups", "setgid", "setuid"]
 
     def test_the_target_users_own_ids_are_used(self, recorded_switch):
         demote_user("stepuser")
 
         by_name = dict(recorded_switch)
-        assert by_name["initgroups"] == ("stepuser", 5678)
+        assert by_name["setgroups"] == ([5678, 27],)
         assert by_name["setgid"] == (5678,)
         assert by_name["setuid"] == (1234,)
 
@@ -96,12 +97,15 @@ class TestDemoteUser:
         with pytest.raises(RuntimeError, match="nosuchuser"):
             demote_user("nosuchuser")
 
-    def test_a_refused_switch_is_reported_by_name(self, monkeypatch):
+    def test_a_refused_switch_is_reported_by_name(self, recorded_switch, monkeypatch):
         # The realistic cause is running without root, where setgid is denied.
         # The OSError alone says "Operation not permitted" and names no user.
-        monkeypatch.setattr(pwd, "getpwnam", lambda _name: FakePasswd())
-        monkeypatch.setattr(os, "initgroups", lambda *_args: None, raising=False)
-
+        #
+        # Built on the fixture so every id-changing call stays substituted. An
+        # earlier version patched only setgid and left os.setuid real, which
+        # was harmless only because setgid failed first - exactly the ordering
+        # the test above exists to catch. Under ansible-test units --docker,
+        # as root, that would have demoted the test runner mid-suite.
         def deny(*_args):
             raise OSError(1, "Operation not permitted")
 
@@ -158,17 +162,98 @@ class TestDemotionHook:
         assert _demotion_hook(None) is None
         assert _demotion_hook("") is None
 
-    def test_a_username_produces_a_hook_that_demotes_to_it(self, monkeypatch):
-        demoted = []
-        monkeypatch.setattr(
-            "ansible_collections.matonb.step.plugins.module_utils.process.demote_user",
-            demoted.append,
-        )
-
+    def test_a_username_produces_a_hook_that_drops_to_it(self, recorded_switch):
         hook = _demotion_hook("stepuser")
+
+        # Nothing has happened yet: the hook runs in the child, after the fork.
+        assert recorded_switch == []
+
         hook()
 
-        assert demoted == ["stepuser"]
+        assert [name for name, arguments in recorded_switch] == ["setgroups", "setgid", "setuid"]
+
+    def test_the_lookup_happens_before_the_fork(self, recorded_switch, monkeypatch):
+        # subprocess reports anything a preexec_fn raises as a bare "Exception
+        # occurred in preexec_fn.", so a name resolved in the child is a name
+        # whose failure the operator never sees. Resolving here means the
+        # RuntimeError still says which user was wrong.
+        looked_up = []
+        monkeypatch.setattr(pwd, "getpwnam", lambda name: looked_up.append(name) or FakePasswd())
+
+        _demotion_hook("stepuser")
+
+        assert looked_up == ["stepuser"]
+
+    def test_an_unknown_user_is_refused_before_anything_forks(self, monkeypatch):
+        def raise_key_error(name):
+            raise KeyError(name)
+
+        monkeypatch.setattr(pwd, "getpwnam", raise_key_error)
+
+        with pytest.raises(RuntimeError, match="nosuchuser"):
+            _demotion_hook("nosuchuser")
+
+
+class TestTheHookReachesSubprocess:
+    """The wire between _demotion_hook and Popen.
+
+    Both halves were tested in isolation and the wire between them was not, so
+    deleting `preexec_fn=_demotion_hook(username)` from both call sites left
+    the whole suite green - a build that never demoted at all. That is the
+    defect this file exists for, so it is asserted directly.
+    """
+
+    @staticmethod
+    def _captured_popen(monkeypatch):
+        """Capture the kwargs run_command hands to Popen.
+
+        Args:
+            monkeypatch: pytest's monkeypatch fixture.
+
+        Returns:
+            dict: filled with the keyword arguments of the next Popen call.
+        """
+        captured = {}
+        real_popen = subprocess.Popen
+
+        class CapturingPopen(real_popen):
+            def __init__(self, *args, **kwargs):
+                captured.update(kwargs)
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(subprocess, "Popen", CapturingPopen)
+        return captured
+
+    def test_a_username_reaches_popen_as_a_preexec_fn(self, recorded_switch, monkeypatch):
+        captured = self._captured_popen(monkeypatch)
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+
+        run_command(["echo", "hello"], username="stepuser")
+
+        assert captured["preexec_fn"] is not None
+
+        # And it is the demotion, not merely some callable: run it here, where
+        # the ids are substituted, and see the drop happen.
+        captured["preexec_fn"]()
+        assert [name for name, arguments in recorded_switch] == ["setgroups", "setgid", "setuid"]
+
+    def test_no_username_reaches_popen_as_no_hook(self, monkeypatch):
+        captured = self._captured_popen(monkeypatch)
+
+        run_command(["echo", "hello"])
+
+        assert captured["preexec_fn"] is None
+
+    def test_the_timeout_path_wires_it_too(self, recorded_switch, monkeypatch):
+        # Two Popen call sites, and only one of them is on the timeout path.
+        captured = self._captured_popen(monkeypatch)
+        monkeypatch.setattr(os, "geteuid", lambda: 0)
+
+        run_command(["echo", "hello"], username="stepuser", timeout=10)
+
+        assert captured["preexec_fn"] is not None
+        captured["preexec_fn"]()
+        assert [name for name, arguments in recorded_switch] == ["setgroups", "setgid", "setuid"]
 
 
 class TestValidateUserSwitch:
@@ -196,6 +281,25 @@ class TestCompletedProcess:
         result = _create_completed_process(["step"], 0, "\x1b[32mok\x1b[0m", None, text=True, strip_ansi=True)
 
         assert result.stdout == "ok"
+
+    def test_stderr_is_sanitized_as_well_as_stdout(self):
+        # The failure message an operator reads is built from stderr, so colour
+        # left in it is colour in the module's reported error.
+        result = _create_completed_process(["step"], 1, None, "\x1b[31mboom\x1b[0m", text=True, strip_ansi=True)
+
+        assert result.stderr == "boom"
+
+    def test_the_command_is_carried_into_the_result(self):
+        result = _create_completed_process(["step", "version"], 0, "", "", text=True, strip_ansi=True)
+
+        assert result.args == ["step", "version"]
+
+    def test_strip_ansi_false_is_honoured(self):
+        # Nothing else threads this flag all the way through, so a
+        # _create_completed_process that ignored it would go unnoticed.
+        result = _create_completed_process(["step"], 0, "\x1b[32mok", None, text=True, strip_ansi=False)
+
+        assert result.stdout == "[32mok"
 
     def test_bytes_are_left_alone(self):
         # sanitize_output works on str. Handing it bytes would raise, so the
@@ -273,6 +377,11 @@ class TestRunCommand:
 
         assert result.stdout.split() == ["one", "two"]
 
+    def test_strip_ansi_false_reaches_the_result(self):
+        result = run_command(["printf", "\x1b[32mok"], strip_ansi=False)
+
+        assert result.stdout == "[32mok"
+
     def test_output_can_be_left_as_bytes(self):
         result = run_command(["echo", "hello"], text=False)
 
@@ -301,17 +410,29 @@ class TestRunWithTimeout:
         with pytest.raises(CommandTimeoutError, match="timed out after"):
             run_command(["sleep", "5"], timeout=0.2)
 
-    def test_the_timed_out_command_is_actually_killed(self, tmp_path):
+    def test_the_timed_out_command_is_actually_killed(self, monkeypatch):
         # Raising while leaving the process running would satisfy the test
         # above and still leak a step process holding the CA's files open.
-        # The marker is written only if the command survived its timeout.
-        marker = tmp_path / "survived"
+        #
+        # Asserted from the signal the child died of rather than by waiting to
+        # see whether it did something: -SIGKILL can only come from the kill()
+        # in the timeout path, and it costs no wall clock. An earlier version
+        # slept 1.5s watching for a marker file and was the slowest thing in
+        # the suite by an order of magnitude.
+        started = []
+        real_popen = subprocess.Popen
+
+        class CapturingPopen(real_popen):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                started.append(self)
+
+        monkeypatch.setattr(subprocess, "Popen", CapturingPopen)
 
         with pytest.raises(CommandTimeoutError):
-            run_command(["sh", "-c", f"sleep 1; touch {marker}"], timeout=0.2)
+            run_command(["sleep", "5"], timeout=0.2)
 
-        time.sleep(1.5)
-        assert not marker.exists()
+        assert started[0].returncode == -signal.SIGKILL
 
     def test_a_failure_inside_the_timeout_still_reports_normally(self):
         with pytest.raises(RuntimeError, match="return code 1"):


### PR DESCRIPTION
Closes #40.

`process.py` was 19% covered while being the file that drops privileges and
enforces the timeout the `provisioner` module's anti-hang design rests on.
Covering it turned up three defects, so this is not only tests.

## Fixes

**`demote_user` did not drop supplementary groups.** It called `setgid` then
`setuid` and nothing else, so a command demoted from root kept root's group
memberships and the access that comes with them. It read as a privilege drop
and was a uid change. Now `setgroups`, `setgid`, `setuid` — in that order,
because once the uid is no longer root none of the three is permitted.

**The demotion ran two NSS lookups between fork and exec.** `getpwnam` and
`getgrouplist` go to the network on a host using SSSD or LDAP, and the forked
child holds a copy of whatever locks were held at fork time — the classic
`preexec_fn` deadlock. It also meant nobody saw why a switch failed:
`subprocess` reports anything a `preexec_fn` raises as `Exception occurred in
preexec_fn.`, so the error naming the missing user was built and discarded.
The lookups now happen in the parent; the hook does syscalls only.

**Two unreachable handlers removed.** `run_command` caught
`subprocess.CalledProcessError` around `Popen` + `communicate()`, which cannot
raise it, and `_run_with_timeout` caught `ProcessLookupError` from
`terminate()`, which `Popen.send_signal` already handles itself (bpo-40550).
Both documented failure modes callers can never see. Deleted rather than
covered — reaching them needed mocks asserting fiction.

Also: `preexec_fn` was installed on every call, including when there was
nothing to demote.

## Tests

`process.py` goes **19% → 100%**. Real commands (`echo`, `false`, `sleep`, a
shell pipeline) rather than a mocked `subprocess`; mocking is confined to the
demotion, where switching user needs root.

Every assertion was mutation-tested — each reinstated defect fails only the
tests that claim the property.

Worth flagging honestly: the first pass of this reached 98% coverage and a
build with `preexec_fn` deleted from **both** `Popen` calls still passed every
test. Both halves were tested in isolation and the wire between them was not.
`TestTheHookReachesSubprocess` closes that, and it is the assertion this issue
actually existed for.

## Tooling

The pre-commit shellcheck hook is pinned to 0.9.0 to match what the sanity
runner ships — the previous 0.11 pin let two SC2015 findings through to a red
CI — and the sanity job is pinned to `ubuntu-24.04` so the pairing cannot drift
when `ubuntu-latest` moves.

## Verification

- `pytest tests/unit -q` — 403 passed
- `pytest --cov` — `process.py` 91 statements, 0 missed
- `ansible-test sanity` exit 0; `ansible-test units` 191 + 211 passed
- `bash tests/integration/run.sh` — PASSED
- `pre-commit run --all-files` — clean

## Not fixed here

`_run_with_timeout` does not bound wall-clock time when the child spawns
children: after `kill()`, `communicate()` blocks until every pipe writer closes.
Measured — `sleep 4 & sleep 4` with `timeout=0.3` raised after 4.00s. The fix
(`start_new_session=True` plus `killpg`) changes process-group semantics for
every command the collection runs, so it wants its own issue and its own
decision.