### PR TITLE
Verify the supported ansible-core range, and give the integration suites a trigger

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,108 @@
+---
+name: Integration
+
+# Neither suite runs on every pull request. Both take minutes rather than
+# seconds, both need Docker, and both reach smallstep's CDN - so on every PR
+# they would make merging anything depend on a third party being up, and the
+# failures people learn to ignore are the ones that fail for reasons unrelated
+# to the change.
+#
+# So: on demand, or when a pull request opts in by carrying the `integration`
+# label. `synchronize` is listed as well as `labeled` so that pushing more
+# commits to an already-labelled PR re-runs them, rather than leaving the last
+# green result standing over code it never saw.
+#
+# Nothing here is a merge gate. A failure is something to read.
+"on":
+  workflow_dispatch:
+  pull_request:
+    types: [labeled, synchronize]
+
+env:
+  ANSIBLE_CORE_VERSION: "2.20.5"
+  PYTHON_VERSION: "3.13"
+
+jobs:
+  # Two jobs rather than one script after another: a role.sh failure must not
+  # bury a run.sh result, and either can be re-run on its own.
+  modules:
+    name: Modules against a real step-ca
+    # Same pin as the sanity job, so the container behaviour these exercise is
+    # not also drifting with the runner image.
+    runs-on: ubuntu-24.04
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || contains(github.event.pull_request.labels.*.name, 'integration')
+
+    steps:
+      # ansible-test is not used here, but role.sh and run.sh resolve the
+      # collection as matonb.step, so the checkout still has to sit at
+      # that path.
+      - name: Checkout into a collection path
+        uses: actions/checkout@v7
+        with:
+          path: ansible_collections/matonb/step
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install ansible-core
+        run: |
+          python -m pip install --upgrade pip
+          pip install "ansible-core==${ANSIBLE_CORE_VERSION}"
+
+      # run.sh drives the step CLI on the runner itself, not only in the
+      # container, so it has to be installed here. From smallstep's own
+      # repository, which is what the collection installs from.
+      - name: Install the step CLI
+        env:
+          KEY_URL: https://packages.smallstep.com/keys/apt/repo-signing-key.gpg
+          KEYRING: /etc/apt/keyrings/smallstep.asc
+          REPO_URL: https://packages.smallstep.com/stable/debian
+        run: |
+          curl -fsSL "$KEY_URL" | sudo tee "$KEYRING" >/dev/null
+          echo "deb [signed-by=$KEYRING] $REPO_URL debs main" \
+            | sudo tee /etc/apt/sources.list.d/smallstep.list >/dev/null
+          sudo apt-get update
+          sudo apt-get install -y step-cli
+          step version
+
+      - name: Run the module suite
+        working-directory: ansible_collections/matonb/step
+        run: bash tests/integration/run.sh
+
+  roles:
+    name: Roles against real systemd
+    runs-on: ubuntu-24.04
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || contains(github.event.pull_request.labels.*.name, 'integration')
+
+    steps:
+      - name: Checkout into a collection path
+        uses: actions/checkout@v7
+        with:
+          path: ansible_collections/matonb/step
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install ansible-core
+        run: |
+          python -m pip install --upgrade pip
+          pip install "ansible-core==${ANSIBLE_CORE_VERSION}"
+
+      # role.sh talks to its containers through community.docker's connection
+      # plugin rather than SSH, and checks for it before doing anything.
+      - name: Install community.docker
+        run: ansible-galaxy collection install community.docker
+
+      # Twelve scenarios across two OS families, in containers with a real
+      # PID 1 systemd. Around seven minutes.
+      - name: Run the role suite
+        working-directory: ansible_collections/matonb/step
+        run: bash tests/integration/role.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,19 @@ name: Test (sanity & units)
       - main
   pull_request:
 
-# ansible-core is pinned for the same reason lint.yml pins its hook versions:
-# the sanity test set changes between minors, so an unpinned install lets CI
-# drift ahead of what anyone verified locally and breaks unrelated PRs on
-# checks the gate has never seen. Bump both together, deliberately.
+# Used by the sanity job. ansible-core is pinned for the same reason lint.yml
+# pins its hook versions: the sanity test set changes between minors, so an
+# unpinned install lets CI drift ahead of what anyone verified locally and
+# breaks unrelated PRs on checks the gate has never seen. Bump both together,
+# deliberately - ansible-core 2.20 requires Python >= 3.12, so the Python
+# version and the pin move as a pair.
 #
-# Note that ansible-core 2.20 requires Python >= 3.12, so the Python version
-# and the pin have to move together too.
+# Sanity runs on this one version only, where units run a matrix. That is not
+# an oversight. ansible-test's sanity suite is a moving target: its own pylint
+# and its own rules differ between minors, so an older leg would report on the
+# age of the test set rather than on this collection, and would need silencing
+# to go green. Units run the collection's own tests, which is the thing worth
+# asking an older ansible-core about.
 env:
   ANSIBLE_CORE_VERSION: "2.20.5"
   PYTHON_VERSION: "3.13"
@@ -51,8 +57,30 @@ jobs:
         run: ansible-test sanity --python ${{ env.PYTHON_VERSION }}
 
   units:
-    name: Unit tests
-    runs-on: ubuntu-latest
+    name: Unit tests (ansible-core ${{ matrix.ansible-core }})
+    runs-on: ubuntu-24.04
+
+    # meta/runtime.yml claims requires_ansible '>=2.14'. Testing only the pin
+    # asserted that range at seven-releases' breadth and verified it at one
+    # point. These two legs are the ends of it: what is claimed, and what is
+    # pinned. Versions in between buy little, since nothing claims anything
+    # specific about them, and each costs a job on every push.
+    #
+    # The pairs are not free choices - ansible-core sets a controller Python
+    # floor per release (2.14 needs >=3.9, 2.20 needs >=3.12), so the two move
+    # together or the leg will not install.
+    #
+    # fail-fast off because "does it still work on the floor" and "does it work
+    # on the pin" are separate questions, and the answer to one should not
+    # cancel the other.
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ansible-core: "2.14.18"
+            python: "3.11"
+          - ansible-core: "2.20.5"
+            python: "3.13"
 
     steps:
       - name: Checkout into a collection path
@@ -63,17 +91,19 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v7
         with:
-          python-version: ${{ env.PYTHON_VERSION }}
+          python-version: ${{ matrix.python }}
 
       - name: Install ansible-core
         run: |
           python -m pip install --upgrade pip
-          pip install "ansible-core==${ANSIBLE_CORE_VERSION}"
+          pip install "ansible-core==${{ matrix.ansible-core }}"
 
       - name: Run unit tests
         working-directory: ansible_collections/matonb/step
         # --requirements installs tests/unit/requirements.txt, which carries
-        # pytest-xdist; ansible-test always invokes pytest with -n.
+        # pytest-xdist; ansible-test always invokes pytest with -n. Older
+        # ansible-test needs it too - without the flag, 2.14 dies with
+        # "unrecognized arguments: --forked -n" rather than running anything.
         run: >-
           ansible-test units
-          --python ${{ env.PYTHON_VERSION }} --requirements
+          --python ${{ matrix.python }} --requirements

--- a/README.md
+++ b/README.md
@@ -641,7 +641,9 @@ repeating the path, so changing `ca_server_password_file` moves both the unit's
 
 Both roles are covered by `tests/integration/role.sh`, which drives them against
 containers running a real systemd — once on Debian and once on Rocky 9. Like the
-module suite it needs docker and is not run by CI.
+module suite it needs docker, so it does not run on every pull request: add the
+`integration` label to a PR to run both suites against it, or start them from
+the Actions tab. Neither gates a merge.
 
 ## Special Notes
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -19,8 +19,11 @@ started on ports 9101 and 9102 and removed on exit, including on failure.
 Override with `STEP_TEST_ADMIN_PORT`, `STEP_TEST_CONFIG_PORT` and
 `STEP_TEST_IMAGE`.
 
-Not run in CI: it pulls an image and needs a Docker daemon, so it should not
-gate a pull request until it has proven stable. Run it before a release, and
+Not run on every pull request: it pulls an image and needs a Docker daemon, so
+it should not gate a merge, and a failure reaching smallstep's CDN says nothing
+about the change under review. Both suites run when a PR carries the
+`integration` label, and from the Actions tab on demand
+(`.github/workflows/integration.yml`). Run it locally before a release, and
 whenever command construction or mode handling changes.
 
 ## What each suite asserts


### PR DESCRIPTION
Addresses #41.

Half of what that issue described is already fixed — it was filed when
`requires_ansible` claimed `>=2.9.10`, which PEP 585 annotations made
impossible, and #46 raised it to `>=2.14`. What was left is that the claim is
never tested and the integration suites never run.

## The supported range is now tested at both ends

CI tested ansible-core 2.20.5 alone, so a range spanning seven minor releases
was asserted and verified at a single point. The units job now runs two legs:

| ansible-core | Python | |
| --- | --- | --- |
| 2.14.18 | 3.11 | the floor `requires_ansible` claims |
| 2.20.5 | 3.13 | what was already pinned |

Verified locally before writing the workflow: **191 + 212 pass on 2.14.18**,
invoked exactly as CI invokes it. The pairs are not free choices — ansible-core
sets a controller Python floor per release, so the two move together or the leg
will not install.

Sanity stays on the pin alone. Its test set moves between minors, so an older
leg would report on the age of ansible-test's own rules rather than on this
collection. The workflow comment says so, since the asymmetry otherwise reads
as an oversight.

## The integration suites have a trigger

`run.sh` and `role.sh` are the only things that exercise the modules against a
real step-ca and the roles against real systemd — `run.sh` is what caught #31,
which unit tests and review both missed — and neither had any trigger at all.

New `.github/workflows/integration.yml` runs both as independent jobs, on
`workflow_dispatch` or when a pull request carries the `integration` label.
`synchronize` is listed alongside `labeled` so pushing to an already-labelled
PR re-runs them rather than leaving a green result standing over code it never
saw.

Deliberately not on every PR: both take minutes, both need Docker, and both
reach smallstep's CDN, so on every PR they would make merging depend on a third
party being up — and a check that fails for reasons unrelated to the change is
a check people learn to ignore. Neither gates a merge.

## Verification

- `actionlint` clean on both workflows.
- `pre-commit run --all-files` clean.
- 2.14 leg proven locally, as above.

**The label gate itself can only be proven here.** A typo in the
`github.event.pull_request.labels.*.name` expression would make it silently
never fire, which is the same "green because it never ran" failure this issue
is about. Label this PR `integration` and both jobs should start; remove it and
they should not. `actionlint` says the expression is valid, which is not the
same as seeing it fire.

## Not included

- The wall-clock timeout defect found during #40 (`_run_with_timeout` does not
  bound elapsed time when the child forks) — still unraised.
- Managed-node Python coverage, which needs a container per Python rather than
  a runner matrix.