### PR TITLE
Make the integration suites actually run in CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -96,10 +96,16 @@ jobs:
           python -m pip install --upgrade pip
           pip install "ansible-core==${ANSIBLE_CORE_VERSION}"
 
-      # role.sh talks to its containers through community.docker's connection
-      # plugin rather than SSH, and checks for it before doing anything.
-      - name: Install community.docker
-        run: ansible-galaxy collection install community.docker
+      # Two collections, for two different reasons. role.sh talks to its
+      # containers through community.docker's connection plugin rather than
+      # SSH, and checks for it before doing anything. community.general is the
+      # ca_server role's own dependency - it uses the capabilities module to
+      # grant CAP_NET_BIND_SERVICE - and without it the play fails at that
+      # task rather than up front.
+      - name: Install the collections the suite and the roles need
+        run: |
+          ansible-galaxy collection install community.docker
+          ansible-galaxy collection install community.general
 
       # Twelve scenarios across two OS families, in containers with a real
       # PID 1 systemd. Around seven minutes.

--- a/tests/integration/role.sh
+++ b/tests/integration/role.sh
@@ -140,7 +140,18 @@ EL_REPO="/etc/yum.repos.d/$REPOSITORY_NAME.repo"
 COLLECTIONS="$WORK/collections"
 mkdir -p "$COLLECTIONS/ansible_collections/matonb"
 ln -s "$REPO_ROOT" "$COLLECTIONS/ansible_collections/matonb/step"
-export ANSIBLE_COLLECTIONS_PATH="$COLLECTIONS"
+
+# Prepended rather than assigned. This variable replaces the search path, it
+# does not add to it, so a bare assignment hides every collection the host
+# already has - including community.general, which ca_server needs for the
+# capabilities module.
+#
+# That went unnoticed for as long as it did because a workstation whose ansible
+# came with a bundled community.general resolves it out of site-packages, which
+# is searched whatever this says. Where ansible-galaxy put it in
+# ~/.ansible/collections instead - a CI runner, a clean venv - the play died at
+# "couldn't resolve module/action 'community.general.capabilities'".
+export ANSIBLE_COLLECTIONS_PATH="$COLLECTIONS:${ANSIBLE_COLLECTIONS_PATH:-$HOME/.ansible/collections:/usr/share/ansible/collections}"
 
 CONTAINER=""
 

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -37,7 +37,7 @@ cleanup() {
         docker volume inspect "$ADMIN_VOLUME" >/dev/null 2>&1 &&
             echo "WARNING: could not remove volume $ADMIN_VOLUME; remove it before re-running" >&2
     fi
-    # The config CA directory is written by the container as uid 1000. If that
+    # The config CA directory is written by the container as this user. If that
     # is not us, drop privileges through the image itself rather than failing.
     if [ -d "$WORK" ] && ! rm -rf "$WORK" 2>/dev/null; then
         docker run --rm -u 0:0 -v "$WORK:/w" "$IMAGE" rm -rf /w/config-ca >/dev/null 2>&1 || true
@@ -58,9 +58,6 @@ require docker
 require step
 require ansible-playbook
 
-# The container writes as uid 1000 into the bind-mounted config CA directory,
-# and this script reads and greps those files.
-[ "$(id -u)" -eq 1000 ] || die "this suite needs to run as uid 1000 to share the bind-mounted CA directory (found $(id -u))"
 
 # A container left behind by a SIGKILLed run would make `docker run --name`
 # fail outright.
@@ -124,14 +121,21 @@ wait_for_ca "$ADMIN_URL" "$ADMIN_DIR/root_ca.crt" "admin CA" "$ADMIN_CONTAINER"
 log "Starting config-mode CA (bind-mounted ca.json) on :$CONFIG_PORT"
 ###############################################################################
 # Bind-mounting means the host-side module and the containerised CA share one
-# ca.json, so `restart_required` can be observed rather than assumed. The image
-# runs as uid/gid 1000, which matches a typical developer account.
+# ca.json, so `restart_required` can be observed rather than assumed.
+#
+# The CA is told to run as whoever is running this script. step-ca creates its
+# directories 0700, owned by the uid it runs as, so the host can read what it
+# writes only when the two match - and this script reads and greps those files
+# throughout. The image defaults to uid 1000, which is a typical developer
+# account and nothing else: a GitHub runner is 1001, and there the suite used
+# to refuse to start rather than run against files it could not open.
 CONFIG_DIR="$WORK/config-ca"
 mkdir -p "$CONFIG_DIR"
 # mktemp -d gives 0700; the container must be able to traverse into it.
 chmod 711 "$WORK"
 
 docker run -d --name "$CONFIG_CONTAINER" \
+    --user "$(id -u):$(id -g)" \
     -p "$CONFIG_PORT:9000" \
     -v "$CONFIG_DIR:/home/step" \
     -e "DOCKER_STEPCA_INIT_NAME=Integration Config CA" \


### PR DESCRIPTION
Follows #48, which added the trigger. Labelling that PR started both jobs — the
gate works — and both failed immediately, for two unrelated reasons neither of
which is a defect in the collection. This fixes both.

## The roles job was missing a collection

`ca_server` uses `community.general.capabilities` to grant
`CAP_NET_BIND_SERVICE`. The job installed `community.docker`, which `role.sh`
needs for its connection plugin, and stopped there — so the play failed part
way through with `couldn't resolve module/action
'community.general.capabilities'` rather than at a requirement check. The
README has said `community.general` is required since the roles were
documented; the workflow simply did not read it.

## The module suite could not run anywhere but uid 1000

`run.sh` began with a hard check that refused to start unless `id -u` was
exactly 1000. That was not arbitrary: step-ca creates its directories `0700`
owned by the uid it runs as, and the script reads and greps those files
throughout, so the container and the host had to be the same user. The check
enforced that by hardcoding one side of it.

1000 is a typical developer account and nothing more. A GitHub runner is 1001,
so the suite died at the guard.

Now the container is told to run as whoever runs the script —
`--user "$(id -u):$(id -g)"` — so the two match by construction and the guard
is gone rather than relaxed.

I reproduced the underlying failure before changing anything: a container run
as 1001 writing into a directory read by uid 1000 creates `drwx------ 1001`
subdirectories the host cannot traverse. The CA starts and serves happily while
the suite sees an empty directory — the same shape as the CI failure.

## Verification

- `bash tests/integration/run.sh` locally, at uid 1000, with the explicit
  `--user`: **PASSED**. That proves no regression, not the fix.
- The fix itself is only provable at a uid that is not 1000, which is what a
  runner is. **Label this PR `integration`** and the modules job is the test.
  The roles job is the test of the other half.

Both suites are exercised only when labelled, so this needs the label to prove
anything at all.