### PR TITLE
test(integration): merge connection options via YAML anchor

### DIFF
--- a/tests/integration/admin_mode.yml
+++ b/tests/integration/admin_mode.yml
@@ -9,7 +9,12 @@
   vars:
     ca_dir: "{{ lookup('env', 'STEP_TEST_ADMIN_DIR') }}"
     ca_url: "{{ lookup('env', 'STEP_TEST_ADMIN_URL') }}"
-    connection_options:
+    # Anchored rather than splatted with `args: "{{ ... }}"`: a templated arg
+    # splat makes ansible-core warn on every task that uses it. New tasks merge
+    # `<<: *conn` - nothing reads connection_options as a var any more, and
+    # going back to the splat idiom brings the warning back. Anchors resolve
+    # within one YAML document, so tasks using it have to stay in this file.
+    connection_options: &conn
       admin_password_file: "{{ ca_dir }}/pass"
       admin_provisioner: admin
       admin_subject: step
@@ -43,24 +48,24 @@
 
     - name: Add an ACME provisioner (check mode)
       matonb.step.provisioner:
+        <<: *conn
         name: acme
         type: ACME
-      args: "{{ connection_options }}"
       check_mode: true
       register: acme_check
 
     - name: Add an ACME provisioner
       matonb.step.provisioner:
+        <<: *conn
         name: acme
         type: ACME
-      args: "{{ connection_options }}"
       register: acme_add
 
     - name: Add it again
       matonb.step.provisioner:
+        <<: *conn
         name: acme
         type: ACME
-      args: "{{ connection_options }}"
       register: acme_again
 
     - name: Assert the mode, the change, and that no restart is demanded
@@ -75,22 +80,22 @@
 
     - name: Add a JWK provisioner with claims
       matonb.step.provisioner:
+        <<: *conn
         name: cicd
         type: JWK
         x509_default: 36h
         x509_max: 72h
         x509_min: 20m
-      args: "{{ connection_options }}"
       register: jwk_add
 
     - name: Add it again
       matonb.step.provisioner:
+        <<: *conn
         name: cicd
         type: JWK
         x509_default: 36h
         x509_max: 72h
         x509_min: 20m
-      args: "{{ connection_options }}"
       register: jwk_again
 
     - name: Assert a password was generated and the claims settled
@@ -143,12 +148,12 @@
 
     - name: Change a claim
       matonb.step.provisioner:
+        <<: *conn
         name: cicd
         type: JWK
         x509_default: 48h
         x509_max: 72h
         x509_min: 20m
-      args: "{{ connection_options }}"
       register: drift
 
     - name: Assert only the changed claim was reconciled
@@ -175,16 +180,16 @@
 
     - name: Remove the ACME provisioner
       matonb.step.provisioner:
+        <<: *conn
         name: acme
         state: absent
-      args: "{{ connection_options }}"
       register: acme_remove
 
     - name: Remove it again
       matonb.step.provisioner:
+        <<: *conn
         name: acme
         state: absent
-      args: "{{ connection_options }}"
       register: acme_remove_again
 
     - name: Assert removal and idempotence

--- a/tests/integration/config_mode.yml
+++ b/tests/integration/config_mode.yml
@@ -17,7 +17,12 @@
     ca_dir: "{{ lookup('env', 'STEP_TEST_CONFIG_DIR') }}"
     ca_url: "{{ lookup('env', 'STEP_TEST_CONFIG_URL') }}"
     container: "{{ lookup('env', 'STEP_TEST_CONFIG_CONTAINER') }}"
-    connection_options:
+    # Anchored rather than splatted with `args: "{{ ... }}"`: a templated arg
+    # splat makes ansible-core warn on every task that uses it. New tasks merge
+    # `<<: *conn` - nothing reads connection_options as a var any more, and
+    # going back to the splat idiom brings the warning back. Anchors resolve
+    # within one YAML document, so tasks using it have to stay in this file.
+    connection_options: &conn
       # ca_config must be explicit here. The CA writes container-absolute paths
       # into config/defaults.json ("ca-config": "/home/step/config/ca.json"),
       # and the step CLI loads that file as its flag defaults, so without this
@@ -30,9 +35,9 @@
   tasks:
     - name: Add an ACME provisioner (check mode)
       matonb.step.provisioner:
+        <<: *conn
         name: acme
         type: ACME
-      args: "{{ connection_options }}"
       check_mode: true
       register: acme_check
 
@@ -44,9 +49,9 @@
 
     - name: Add an ACME provisioner
       matonb.step.provisioner:
+        <<: *conn
         name: acme
         type: ACME
-      args: "{{ connection_options }}"
       register: acme_add
 
     - name: Assert the mode, the change, and that a restart IS demanded
@@ -65,9 +70,9 @@
     # "provisioner with name acme already exists" - failing this task.
     - name: Re-add immediately, without reloading the CA
       matonb.step.provisioner:
+        <<: *conn
         name: acme
         type: ACME
-      args: "{{ connection_options }}"
       register: acme_again
 
     - name: The provisioner landed in ca.json, not the database
@@ -95,26 +100,26 @@
 
     - name: Add a JWK provisioner with a claim
       matonb.step.provisioner:
+        <<: *conn
         name: cicd
         type: JWK
         x509_min: 20m
-      args: "{{ connection_options }}"
       register: jwk_add
 
     - name: Re-run with the same claim, still without a reload
       matonb.step.provisioner:
+        <<: *conn
         name: cicd
         type: JWK
         x509_min: 20m
-      args: "{{ connection_options }}"
       register: jwk_again
 
     - name: Change the claim, still without a reload
       matonb.step.provisioner:
+        <<: *conn
         name: cicd
         type: JWK
         x509_min: 45m
-      args: "{{ connection_options }}"
       register: drift
 
     - name: Assert the generated password, idempotence and reconciliation
@@ -132,9 +137,9 @@
     # leaves the provisioner in ca.json.
     - name: Remove the ACME provisioner, still without a reload
       matonb.step.provisioner:
+        <<: *conn
         name: acme
         state: absent
-      args: "{{ connection_options }}"
       register: acme_remove
 
     - name: Assert removal happened and demands a restart too
@@ -183,16 +188,16 @@
 
     - name: Add a provisioner with no CA running at all
       matonb.step.provisioner:
+        <<: *conn
         name: offline
         type: ACME
-      args: "{{ connection_options }}"
       register: offline_add
 
     - name: Re-run with the CA still down
       matonb.step.provisioner:
+        <<: *conn
         name: offline
         type: ACME
-      args: "{{ connection_options }}"
       register: offline_again
 
     - name: Assert the change landed and is still idempotent


### PR DESCRIPTION
## What

ansible-core 2.20 emits `Using a template for task args is unsafe in some situations` once per task whose args are a templated splat. The module suite used `args: "{{ connection_options }}"` on 17 provisioner tasks — 8 in `admin_mode.yml`, 9 in `config_mode.yml` — so every run buried its real output in warnings.

The shared mapping is now anchored (`connection_options: &conn`) and merged into each task's own args with `<<: *conn`, which puts the keys in place at YAML parse time, where the warning does not apply.

## Behaviour

Unchanged. The anchor keys are disjoint from every task-level key (`name`, `type`, `state`, `x509_*`), and inline keys still win over the shared ones exactly as they did with the splat. The effective module args were reconstructed old-vs-new through ansible-core 2.20.5's own loader for all 17 tasks: keys and values identical.

The "Missing admin credentials must fail immediately, not hang" task deliberately keeps its explicit incomplete credentials instead of the anchor. Merging `*conn` there would hand it the `admin_*` keys and the anti-hang assertion that follows would stop testing anything.

## Verification

- `bash tests/integration/run.sh` — passed end to end, both plays `failed=0`. The warning appears 0 times in the log; it was 17 before.
- `pre-commit run --all-files` — clean.
- `pytest tests/unit -q` — 403 passed.
- `ansible-playbook --syntax-check` — clean on both playbooks.

Labelled `integration` so the Docker-backed suites run here rather than being taken on trust — this change touches nothing else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HVhY5sGAjhRSxoxNsG5ugh