### PR TITLE
fix(tests): give root a read bit on /etc/shadow in the redhat image

### DIFF
--- a/tests/integration/Dockerfile.redhat
+++ b/tests/integration/Dockerfile.redhat
@@ -17,6 +17,20 @@ RUN dnf -y install --setopt=install_weak_deps=False \
         systemd \
     && dnf clean all
 
+# The image ships /etc/shadow at mode 0000 - root reads it anyway, via
+# CAP_DAC_OVERRIDE through PAM's unix_chkpwd helper. On a Docker host running
+# Ubuntu 24.04 (this suite's own CI runner included), an AppArmor profile
+# scoped to EL9's unix_chkpwd denies it that capability, and every become
+# fails with "PAM account management error: Authentication service cannot
+# retrieve authentication info" the moment anything does become_user. Giving
+# root an explicit read bit means PAM never needs the capability at all.
+# Reproduced identically on rockylinux and almalinux; EL10 builds of both
+# were unaffected despite shipping the same 0000 permission, so this is
+# pinned to what el9's unix_chkpwd trips rather than the mode itself.
+# Upstream: https://github.com/rocky-linux/sig-cloud-instance-images/issues/56
+# #50.
+RUN chmod 0400 /etc/shadow
+
 STOPSIGNAL SIGRTMIN+3
 
 CMD ["/usr/sbin/init"]


### PR DESCRIPTION
## Summary

- Fixes #50: the roles suite's redhat family failed the moment any task did `become_user` (`role_initialize.yml`'s "Initialize the CA"), with sudo reporting `PAM account management error: Authentication service cannot retrieve authentication info` then `a password is required`.
- strace of the failing sudo call on this suite's own GitHub Actions runner pinned it to one syscall: a child process, running as `uid 0`, got `EACCES` opening `/etc/shadow`. The image ships that file at mode `0000`; root normally reads it anyway via `CAP_DAC_OVERRIDE`, exercised through PAM's `unix_chkpwd` helper. On the runner (Ubuntu 24.04), a host-level AppArmor profile scoped to EL9's `unix_chkpwd` denies it that capability - matches the exact same failure reported upstream: https://github.com/rocky-linux/sig-cloud-instance-images/issues/56
- Ruled out first: `apparmor=unconfined` on the container itself, since the denial comes from a profile pinned to the host's copy of the `unix_chkpwd` binary rather than the container's own profile, so it does nothing. A local rebuild on Docker Desktop/WSL2 (kernel 5.15 rather than the runner's 6.17) never reproduced this either - matches the upstream reports of it being specific to real docker-ce hosts.
- A same-flags repro matrix against `rockylinux:9`, `almalinux:9`, `rockylinux:10`, and `almalinux:10` confirmed all four ship `/etc/shadow` at `0000`, but only the EL9 pair failed - so this pins to whatever EL9's `unix_chkpwd` build trips rather than the permission bit itself. The role only declares EL9 support, so that's the pair that matters here regardless.
- `chmod 0400` gives root an explicit read bit, so PAM never needs the denied capability at all - the fix the upstream thread converged on.

## Test plan

- [x] Full `Integration` workflow run on this branch: both jobs green, roles suite passed all 12 scenarios (redhat + debian) - https://github.com/matonb/step/actions/runs/31313816846