### PR TITLE
docs(requirements): state the managed node Python floor as 3.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,6 +70,12 @@ jobs:
     # floor per release (2.14 needs >=3.9, 2.20 needs >=3.12), so the two move
     # together or the leg will not install.
     #
+    # Within what 2.14 allows, the older leg pins 3.9 rather than 3.11 because
+    # 3.9 is this collection's own floor - what the PEP 585 annotations in the
+    # modules require, and what RHEL 9 and Debian 11 ship as system Python.
+    # Running it at 3.11 would leave the floor stated in README.md and never
+    # executed.
+    #
     # fail-fast off because "does it still work on the floor" and "does it work
     # on the pin" are separate questions, and the answer to one should not
     # cancel the other.
@@ -78,7 +84,7 @@ jobs:
       matrix:
         include:
           - ansible-core: "2.14.18"
-            python: "3.11"
+            python: "3.9"
           - ansible-core: "2.20.5"
             python: "3.13"
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ including against a CA that is not running.
 
 - ansible-core 2.14 or higher — the roles use `ansible.builtin.systemd_service`,
   which does not exist before it
+- Python 3.9 or higher **on the managed node**, where the modules actually run —
+  they annotate with PEP 585 builtin generics in positions evaluated at import,
+  so an older interpreter raises `TypeError` before a task does any work. This
+  is separate from the line above: `requires_ansible` constrains the controller
+  only. 3.9 is what RHEL/Rocky 9 and Debian 11 ship as their system Python, and
+  current ansible-core's own lowest supported managed node
 - `community.general`, for the `capabilities` module the `ca_server` role uses
 - A Debian- or RedHat-family target, for the roles. The modules work anywhere
   step-ca does

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,14 @@ dev = [
     "pre-commit>=4.2.0",
     "ruff>=0.12.4",
     "yamllint>=1.35.0",
+    # ansible-core is deliberately absent: it arrives transitively through
+    # ansible-lint, and a bound here would be a second number free to drift out
+    # of step with requires_ansible in meta/runtime.yml, which is where the
+    # supported floor is declared. Nor would a bound here hold that floor in
+    # practice - current ansible-lint requires ansible-core >= 2.16, above the
+    # 2.14 the collection supports. Testing at the floor means installing
+    # ansible-core directly, which is what .github/workflows/test.yml does.
     "ansible-lint>=24.12.0",
-    "ansible-core>=2.15.0",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
Closes #41.

## Note on the issue

Three of #41's four items were already fixed before this branch, and the issue's headline premise is stale:

| Item | Where |
| --- | --- |
| `requires_ansible: '>=2.9.10'` unachievable | Fixed earlier — now `>=2.14` (`6bbaf01`) |
| CI tests one combination only | Fixed earlier — units matrix; **this PR** moves the floor leg to 3.9 so it is executed, not merely asserted |
| Integration suite has no trigger | Fixed earlier — `integration.yml` (`da94f7d`) |
| State the minimum managed-node Python in the README | **This PR** |

## What this changes

`requires_ansible` constrains the **controller** only, so nothing told a user which Python the modules need on the **managed node**, where they actually run. The modules annotate with PEP 585 builtin generics in positions evaluated at import — including class- and module-level ones — so on 3.8 they raise `TypeError` before a task does any work.

- **`README.md`** — states the 3.9 managed-node floor and why it is a separate requirement.
- **`.github/workflows/test.yml`** — the older units leg moves from Python 3.11 to 3.9. It was asserting a floor it never ran.
- **`pyproject.toml`** — drops the `ansible-core` bound from the `dev` extra. It arrives transitively via ansible-lint, and a second version number could only drift out of step with `meta/runtime.yml`. (It was `>=2.15.0`, already contradicting the declared `>=2.14`.)

No module or role code is touched.

## Why 3.9

It is what RHEL/Rocky 9 and Debian 11 ship as system Python, and current ansible-core's own lowest supported managed node (`REMOTE_ONLY_PYTHON_VERSIONS[0]` is `3.9` in both the pinned 2.20.5 and the latest 2.21.2). `tests/integration/role.sh` already exercises the modules on it — `Dockerfile.redhat` builds on `rockylinux/rockylinux:9`, whose `python3` is 3.9.25.

## Testing

- `ansible-test units --python 3.9 --requirements` with ansible-core 2.14.18 — **403 passed** (191 modules + 212 module_utils). This is the exact command the changed CI leg runs.
- `ansible-test sanity --python 3.13` with ansible-core 2.20.5 — all 24 tests pass.
- `pytest tests/unit -q` on 3.13 — 403 passed.
- `pre-commit run --all-files` — passed.
- All plugin files compile on a real CPython 3.9.25; verified on a real CPython 3.8.20 that the annotations do raise `TypeError` in all three positions the code uses.
- `.[dev]` still resolves `ansible-core==2.21.2` transitively after the bound is dropped.

Integration suites were not run — nothing here touches module or role behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3SLgdmivJsGkd6xYbv3k2