### PR TITLE
feat(release): publish the collection to Ansible Galaxy

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,16 +7,35 @@ name: Integration
 # failures people learn to ignore are the ones that fail for reasons unrelated
 # to the change.
 #
-# So: on demand, or when a pull request opts in by carrying the `integration`
-# label. `synchronize` is listed as well as `labeled` so that pushing more
-# commits to an already-labelled PR re-runs them, rather than leaving the last
-# green result standing over code it never saw.
+# So they run on the pull requests that can actually break them: those touching
+# the modules, the roles, or the suites themselves. That replaced an opt-in
+# `integration` label, which put the decision on whoever opened the pull request
+# and so was missed exactly when it mattered. Anything outside these paths can
+# still be run by hand from the Actions tab.
 #
-# Nothing here is a merge gate. A failure is something to read.
+# Nothing here is a *merge* gate. A failure on a pull request is something to
+# read. It is a *release* gate: release.yml calls this workflow, and a failure
+# there stops the version being tagged, so nothing reaches Galaxy that these
+# suites have not run against. That does couple releasing to smallstep's CDN
+# being up, which is the price of not publishing something untested - and the
+# paths below are what keep the release run from being the first time these
+# suites see the code, which would find the problem a merge too late.
 "on":
+  workflow_call:
   workflow_dispatch:
   pull_request:
-    types: [labeled, synchronize]
+    paths:
+      - plugins/**
+      - roles/**
+      - tests/integration/**
+
+# Read-only, and stated rather than inherited. Called from release.yml these
+# jobs would otherwise take its `contents: write` - and actions/checkout leaves
+# that token in .git/config in the workspace while role.sh runs privileged
+# containers and both jobs install third-party artifacts from smallstep's apt
+# repository and from Galaxy. Neither job writes anything to this repository.
+permissions:
+  contents: read
 
 env:
   ANSIBLE_CORE_VERSION: "2.20.5"
@@ -30,10 +49,6 @@ jobs:
     # Same pin as the sanity job, so the container behaviour these exercise is
     # not also drifting with the runner image.
     runs-on: ubuntu-24.04
-    if: >-
-      github.event_name == 'workflow_dispatch'
-      || contains(github.event.pull_request.labels.*.name, 'integration')
-
     steps:
       # ansible-test is not used here, but role.sh and run.sh resolve the
       # collection as matonb.step, so the checkout still has to sit at
@@ -76,10 +91,6 @@ jobs:
   roles:
     name: Roles against real systemd
     runs-on: ubuntu-24.04
-    if: >-
-      github.event_name == 'workflow_dispatch'
-      || contains(github.event.pull_request.labels.*.name, 'integration')
-
     steps:
       - name: Checkout into a collection path
         uses: actions/checkout@v7

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,112 @@
+---
+name: Publish to Ansible Galaxy
+
+# Two ways in, and deliberately not `release: [published]`. semantic-release
+# creates the GitHub release using the default GITHUB_TOKEN, and GitHub does not
+# start workflow runs from events raised by that token, so that trigger would
+# never fire. release.yml calls this workflow instead.
+#
+# workflow_dispatch is the way back. A publish can fail long after the tag and
+# the GitHub release exist - a rejected token, a Galaxy outage, a version
+# already uploaded - and re-running the release workflow does not republish: it
+# checks out the commit that was pushed, whose galaxy.yml predates the bump,
+# finds the tag already present, and concludes nothing was released. Running
+# this against the tag is what fixes it.
+#
+# Note what that hatch costs: a dispatched run publishes whatever tag it is
+# given, with none of the gates release.yml puts in front of a release. That is
+# deliberate - the point of a recovery path is to work when the normal one has
+# not - but it means a tag published this way is only as tested as it was when
+# it was cut.
+"on":
+  workflow_call:
+    inputs:
+      tag:
+        description: Tag to build and publish, for example v1.3.3
+        required: true
+        type: string
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Tag to build and publish, for example v1.3.3
+        required: true
+        type: string
+
+# Read-only, and stated rather than inherited. Called, this would otherwise take
+# release.yml's `contents: write` plus issues and pull-requests, none of which a
+# checkout-and-upload needs. Dispatched there is no caller to inherit from, so
+# it would fall back to the repository's default workflow permissions - a
+# setting outside this file that can change without anyone editing it.
+permissions:
+  contents: read
+
+# Only ansible-galaxy runs here. Pinned, and moving as a pair, for the reasons
+# set out in test.yml: ansible-core sets a controller Python floor per release,
+# and 2.20 needs >= 3.12.
+env:
+  ANSIBLE_CORE_VERSION: "2.20.5"
+  PYTHON_VERSION: "3.13"
+
+jobs:
+  publish:
+    name: Build and publish
+    runs-on: ubuntu-24.04
+
+    steps:
+      # First, because the build below is cheap but the failure it prevents is
+      # confusing: ansible-galaxy reports a missing token as an authentication
+      # error against Galaxy, which reads like a problem at the far end.
+      #
+      # Duplicated verbatim in release.yml's preflight job, deliberately - see
+      # the note there for why this is not a composite action. Neither copy is
+      # redundant: preflight guards the release path, this one guards the
+      # workflow_dispatch path, which has no caller to have checked anything.
+      # If ANSIBLE_GALAXY_API_KEY is ever renamed, both copies have to move.
+      - name: Check the Galaxy token is present
+        env:
+          GALAXY_API_KEY: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
+        run: |
+          if [ -z "$GALAXY_API_KEY" ]; then
+            echo "::error::ANSIBLE_GALAXY_API_KEY is not set. Generate a" \
+                 "token at galaxy.ansible.com and add it as a repository" \
+                 "secret."
+            exit 1
+          fi
+
+      # The tag rather than the branch. galaxy.yml at that tag already holds the
+      # version semantic-release wrote, so the artifact takes its version from
+      # the one file that decides it, with nothing else needing to agree.
+      - name: Checkout the tag
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.tag }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Install ansible-core
+        run: |
+          python -m pip install --upgrade pip
+          pip install "ansible-core==${ANSIBLE_CORE_VERSION}"
+
+      # Built outside the checkout, so the output directory cannot become build
+      # input, and published by glob: that directory is created fresh and holds
+      # exactly one artifact, so nothing here has to restate the version.
+      #
+      # What lands in the artifact is decided by build_ignore in the galaxy.yml
+      # *at the checked-out tag*, not the one on main. That only matters when
+      # dispatching against a tag from before build_ignore was populated -
+      # v1.3.3 and earlier hold an empty list, so a build there ships .github/,
+      # .vscode/ and the development files. Fine for the recovery case this
+      # workflow exists for, which republishes a tag made after this change;
+      # worth knowing before backfilling Galaxy with older versions.
+      - name: Build and publish the collection
+        env:
+          GALAXY_API_KEY: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
+        run: |
+          ansible-galaxy collection build --output-path "$RUNNER_TEMP/dist"
+          ansible-galaxy collection publish \
+            "$RUNNER_TEMP"/dist/*.tar.gz \
+            --api-key "$GALAXY_API_KEY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,92 @@ permissions:
   issues: write # optional, for semantic-release comments
   pull-requests: write # optional, for semantic-release comments
 
+# semantic-release used to run within a minute of the push. It now waits behind
+# the test and integration suites, which widens the window in which a second
+# merge can start its own run to something over ten minutes. Two runs at
+# different commits both compute the same next version and race to push the
+# tag; the loser fails on a non-fast-forward, so the result is a red run rather
+# than a bad release, but serialising avoids it entirely.
+#
+# Not cancel-in-progress: cancelling a run part-way through `semantic-release
+# version` is the one thing that can leave a tag pushed with nothing published.
+#
+# Note that this holds at most one run waiting, rather than a full queue. A
+# third merge arriving while one runs and one waits cancels the waiting run and
+# takes its place. Nothing goes untested by that - the surviving run checks out
+# a tree containing the cancelled run's commits, so its gates cover them and its
+# release includes them - but those commits get no gate result under their own
+# SHA. Use the pull request for per-commit results; this is a release gate.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
+  # Everything the release job does is irreversible - the version is bumped,
+  # pushed, tagged and announced. So the two things that can be known in
+  # advance are established first: that the token needed to finish the job
+  # exists, and that the suites below pass. A missing token found later would
+  # leave a version tagged and released but absent from Galaxy.
+  #
+  # Cheap, and first, so a missing secret fails in seconds rather than after the
+  # ten minutes the suites take. It establishes only that the secret is set;
+  # a revoked or wrong-scope token still gets as far as the publish.
+  preflight:
+    name: Preflight
+    # Pinned rather than latest, matching the other workflows, so nothing here
+    # changes the day the label moves.
+    runs-on: ubuntu-24.04
+
+    steps:
+      # Duplicated verbatim in publish.yml, deliberately. Deduplicating it into
+      # a local composite action would mean checking the repository out first,
+      # since that is the only way a composite action becomes usable - and this
+      # job's whole value is failing within seconds of the push, with no
+      # checkout at all. Six lines of shell is the cheaper of the two costs.
+      # If ANSIBLE_GALAXY_API_KEY is ever renamed, both copies have to move.
+      - name: Check the Galaxy token is present
+        env:
+          GALAXY_API_KEY: ${{ secrets.ANSIBLE_GALAXY_API_KEY }}
+        run: |
+          if [ -z "$GALAXY_API_KEY" ]; then
+            echo "::error::ANSIBLE_GALAXY_API_KEY is not set. Generate a" \
+                 "token at galaxy.ansible.com and add it as a repository" \
+                 "secret."
+            exit 1
+          fi
+
+  # The release gates. Both run before the release job rather than before the
+  # publish job, deliberately: gating the publish alone would let a failure
+  # leave a tag and a GitHub release for a version that never shipped, which is
+  # the state this workflow is otherwise arranged to avoid. A failure in either
+  # means nothing happened at all.
+  #
+  # Both from preflight rather than one after the other. They answer separate
+  # questions - does the code hold up, and does it work against a real step-ca -
+  # and a failure in one is not a reason to stop asking the other.
+  #
+  # Unconditional rather than only when a release is due. semantic-release can
+  # predict that, but only from a branch in a release group, so the prediction
+  # cannot be checked anywhere except on main - and a wrong one silently skips
+  # releases. The cost is these suites running on merges that release nothing.
+  test:
+    name: Test
+    needs: preflight
+    uses: ./.github/workflows/test.yml
+
+  integration:
+    name: Integration
+    needs: preflight
+    uses: ./.github/workflows/integration.yml
+
   release:
     name: Semantic Release
+    needs: [test, integration]
     runs-on: ubuntu-latest
+
+    outputs:
+      released: ${{ steps.release.outputs.released }}
+      tag: ${{ steps.release.outputs.tag }}
 
     steps:
       - name: Checkout repository
@@ -31,8 +113,39 @@ jobs:
           python -m pip install --upgrade pip
           pip install 'python-semantic-release>=10,<11'
 
+      # `semantic-release version` is a no-op when nothing since the last tag
+      # is releasable, and exits 0 either way - so exit status cannot tell the
+      # publish job whether to run. The last released tag can: it only moves
+      # when a release actually happened. Empty output is the legitimate
+      # "never released" answer, and the reads are deliberately not guarded, so
+      # a genuine failure stops the job instead of being read as either.
       - name: Run semantic-release
+        id: release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          before="$(semantic-release version --print-last-released-tag)"
           semantic-release version
+          after="$(semantic-release version --print-last-released-tag)"
+
+          if [ -n "$after" ] && [ "$before" != "$after" ]; then
+            echo "Released ${before:-none} -> ${after}"
+            echo "released=true" >> "$GITHUB_OUTPUT"
+            echo "tag=${after}" >> "$GITHUB_OUTPUT"
+          else
+            echo "No release made; nothing to publish."
+          fi
+
+  # Called rather than left to trigger itself on `release: published`.
+  # semantic-release creates that release with the default GITHUB_TOKEN, and
+  # GitHub does not start workflow runs from events raised by that token, so
+  # the trigger would never fire. publish.yml also carries a workflow_dispatch,
+  # which is the way back when a publish fails after the tag already exists.
+  publish:
+    name: Publish
+    needs: release
+    if: needs.release.outputs.released == 'true'
+    uses: ./.github/workflows/publish.yml
+    with:
+      tag: ${{ needs.release.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,11 +1,24 @@
 ---
 name: Test (sanity & units)
 
+# No `push: main` trigger. release.yml calls this workflow on every push to
+# main, so keeping one would run both suites twice for each merge rather than
+# widening coverage. Calling it rather than leaving it to run alongside is the
+# point: as a separate workflow it raced the release, so a version could be
+# tagged and published while sanity and units were still running or already red.
+#
+# workflow_dispatch is kept so these suites can still be run against main on
+# their own. Without it the only way to reach them there would be re-running a
+# release, which drags semantic-release along with it.
 "on":
-  push:
-    branches:
-      - main
+  workflow_call:
+  workflow_dispatch:
   pull_request:
+
+# Read-only, and stated rather than inherited, so being called from release.yml
+# does not hand these jobs its `contents: write`. Both only read the checkout.
+permissions:
+  contents: read
 
 # Used by the sanity job. ansible-core is pinned for the same reason lint.yml
 # pins its hook versions: the sanity test set changes between minors, so an

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -62,7 +62,48 @@ homepage: https://github.com/matonb/step
 issues: https://github.com/matonb/step/issues
 
 # List of file patterns to exclude from collection build artifact
-build_ignore: []
+#
+# tests/ is deliberately NOT excluded. Shipping it lets someone who installs the
+# collection re-run the suite where they installed it, on their own Python and
+# ansible-core, rather than taking this repository's CI at its word - and the
+# comments in it record why the guards around the CA's private keys exist.
+build_ignore:
+  # Local state. None of this is ever in a CI checkout, which builds from a
+  # clean tag, so these entries earn their place when building by hand: without
+  # them the artifact carries .ansible's nested self-install of this collection,
+  # whatever the ruff and pytest caches happen to hold, and - in a tree that has
+  # one - a virtualenv's own copy of the Python interpreter. .gitignore already
+  # lists most of this, which ansible-galaxy does not read.
+  - .ansible
+  - .claude
+  - .coverage
+  - .coverage.*
+  - .pytest_cache
+  - .pytest-collection-root
+  - .ruff_cache
+  - .venv
+  - venv
+  - htmlcov
+  - '*.egg-info'
+  - build
+  - dist
+  - ansible.log
+  - CLAUDE.md
+  # Development and CI configuration. Tracked, so it would otherwise ship, and
+  # of no use to anyone consuming the collection - it only exposes internals
+  # that are already readable on GitHub by anyone who wants them. pyproject.toml
+  # is here rather than kept for the shipped tests deliberately: it configures
+  # ruff and semantic-release only, and holds no pytest settings, so excluding
+  # it takes nothing away from running tests/ where the collection is installed.
+  # `templates` is this repository's changelog template for semantic-release,
+  # not the roles' own templates - those live under roles/<name>/templates and
+  # are untouched by this entry.
+  - .github
+  - .gitignore
+  - .pre-commit-config.yaml
+  - .vscode
+  - pyproject.toml
+  - templates
 
 # Example (disabled) for using a manifest instead of build_ignore
 # manifest:


### PR DESCRIPTION
Closes #55

The release workflow bumped the version, tagged it and created a GitHub release, then stopped. Nothing built or published the collection, so `ansible-galaxy collection install matonb.step` did not work.

A push to `main` that produces a release now publishes that version to Galaxy; one that produces no release publishes nothing.

```
preflight → { test, integration } → release → publish
```

## Design notes

**Both suites gate the release, not the publish.** Gating the publish alone would let a failure leave a tag and a GitHub release for a version that never shipped — the exact state this arrangement exists to avoid. A failure in either gate now means nothing happened at all.

**`test.yml` loses its own `push: main` trigger.** `release.yml` calls it, so keeping both would run sanity and the unit matrix twice per merge without covering anything new. `pull_request` is untouched, so PR checks are unchanged. It gains `workflow_dispatch` so the suites can still be run against `main` on their own.

**Publishing is its own workflow, not a step.** A publish can fail long after the tag and GitHub release exist, and re-running the release does not republish — it checks out the pushed commit, finds the tag present, and concludes nothing was released. `publish.yml` can be dispatched against a tag to recover. It is *called* rather than triggered by `release: published`, because semantic-release creates that release with the default `GITHUB_TOKEN` and GitHub does not start workflow runs from events raised by that token.

**Integration runs on paths rather than a label.** Previously opt-in via an `integration` label. As a release gate that would mean the release run is often the first time those suites see merged code, finding failures a merge too late — and an opt-in label is missed exactly when it matters. Now runs on any PR touching `plugins/`, `roles/` or `tests/integration/`.

**`build_ignore` was empty**, so a build from a working tree swallowed local state — `.ansible/`'s nested self-install, the caches, a virtualenv if present. `tests/` is deliberately still shipped so the suite can be re-run where the collection is installed; `pyproject.toml` and the root `templates/` are not, being ruff/semantic-release config with no consumer value.

**Read-only tokens.** `publish.yml`, `test.yml` and `integration.yml` all declare `permissions: contents: read` rather than inheriting `release.yml`'s write scope — relevant because `actions/checkout` persists that token in the workspace while `role.sh` runs privileged containers.

**`concurrency`** serialises release runs, which now wait behind ~12 minutes of gates rather than starting within a minute. `cancel-in-progress: false`, since cancelling mid-`semantic-release version` is the one thing that can strand a pushed tag.

## Prerequisite before merge

⚠️ **The repository secret `ANSIBLE_GALAXY_API_KEY` must exist before this merges.** Until it does, `preflight` fails and *every* push to `main` goes red with no release cut. The `matonb` namespace must also exist on Galaxy and be owned by the linked account.

## Verification

- `pre-commit run --all-files` — passes
- `actionlint` — clean on all four workflows
- `pytest tests/unit -q` — 403 passed
- Artifact built and inspected: `pyproject.toml` and root `templates/` excluded, `roles/ca_server/templates/unit.j2` retained, `tests/` retained

Not verified: publishing itself. It needs a real release and a real token, and Galaxy versions are immutable, so there is no safe rehearsal. Note also that under semantic-release's defaults only `feat`, `fix` and `perf` trigger a release — a `ci:` commit does not, so **merging this PR will not exercise the publish path**. The first `feat:` or `fix:` afterwards is the live test.

On the first real publish, read the Galaxy import log once. If its sanity run fails on the PEP 585 annotations, restoring `tests/config.yml` with `modules: python_requires: '>=3.9'` is the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3SLgdmivJsGkd6xYbv3k2