### PR TITLE
fix(collection): rename to matonb.smallstep

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -51,12 +51,12 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       # ansible-test is not used here, but role.sh and run.sh resolve the
-      # collection as matonb.step, so the checkout still has to sit at
+      # collection as matonb.smallstep, so the checkout still has to sit at
       # that path.
       - name: Checkout into a collection path
         uses: actions/checkout@v7
         with:
-          path: ansible_collections/matonb/step
+          path: ansible_collections/matonb/smallstep
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -85,7 +85,7 @@ jobs:
           step version
 
       - name: Run the module suite
-        working-directory: ansible_collections/matonb/step
+        working-directory: ansible_collections/matonb/smallstep
         run: bash tests/integration/run.sh
 
   roles:
@@ -95,7 +95,7 @@ jobs:
       - name: Checkout into a collection path
         uses: actions/checkout@v7
         with:
-          path: ansible_collections/matonb/step
+          path: ansible_collections/matonb/smallstep
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -121,5 +121,5 @@ jobs:
       # Twelve scenarios across two OS families, in containers with a real
       # PID 1 systemd. Around seven minutes.
       - name: Run the role suite
-        working-directory: ansible_collections/matonb/step
+        working-directory: ansible_collections/matonb/smallstep
         run: bash tests/integration/role.sh

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,11 +1,28 @@
 ---
 name: Lint (Ansible & Python)
 
+# No `push: main` trigger. release.yml calls this workflow on every push to
+# main, so keeping one would mostly lint twice per merge. Calling it rather
+# than leaving it to run alongside is the point: as a separate workflow it
+# raced the release, so a version could be tagged and published while lint was
+# still running or already red.
+#
+# One thing is genuinely given up. A push-triggered run had no concurrency
+# group, so it ran for every push to main under its own SHA; called, it
+# inherits release.yml's group, where a third merge cancels the waiting run.
+# The content is still linted - the surviving run's tree contains the cancelled
+# commits - but those commits get no lint result of their own.
+#
+# workflow_dispatch is kept so lint can still be run against main on its own.
 "on":
-  push:
-    branches:
-      - main
+  workflow_call:
+  workflow_dispatch:
   pull_request:
+
+# Read-only, and stated rather than inherited, so being called from release.yml
+# does not hand this job its `contents: write`. Linting only reads the checkout.
+permissions:
+  contents: read
 
 jobs:
   lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,14 @@ jobs:
   # predict that, but only from a branch in a release group, so the prediction
   # cannot be checked anywhere except on main - and a wrong one silently skips
   # releases. The cost is these suites running on merges that release nothing.
+  # No `needs: preflight`, unlike the two below. preflight only establishes
+  # that the Galaxy token exists, and whether a release can be published has no
+  # bearing on whether the code lints. Gating it there would mean a missing or
+  # rotated secret left a push to main with nothing linted at all.
+  lint:
+    name: Lint
+    uses: ./.github/workflows/lint.yml
+
   test:
     name: Test
     needs: preflight
@@ -90,7 +98,7 @@ jobs:
 
   release:
     name: Semantic Release
-    needs: [test, integration]
+    needs: [lint, test, integration]
     runs-on: ubuntu-latest
 
     outputs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Checkout into a collection path
         uses: actions/checkout@v7
         with:
-          path: ansible_collections/matonb/step
+          path: ansible_collections/matonb/smallstep
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -66,7 +66,7 @@ jobs:
           pip install "ansible-core==${ANSIBLE_CORE_VERSION}"
 
       - name: Run sanity tests
-        working-directory: ansible_collections/matonb/step
+        working-directory: ansible_collections/matonb/smallstep
         run: ansible-test sanity --python ${{ env.PYTHON_VERSION }}
 
   units:
@@ -105,7 +105,7 @@ jobs:
       - name: Checkout into a collection path
         uses: actions/checkout@v7
         with:
-          path: ansible_collections/matonb/step
+          path: ansible_collections/matonb/smallstep
 
       - name: Set up Python
         uses: actions/setup-python@v7
@@ -118,7 +118,7 @@ jobs:
           pip install "ansible-core==${{ matrix.ansible-core }}"
 
       - name: Run unit tests
-        working-directory: ansible_collections/matonb/step
+        working-directory: ansible_collections/matonb/smallstep
         # --requirements installs tests/unit/requirements.txt, which carries
         # pytest-xdist; ansible-test always invokes pytest with -n. Older
         # ansible-test needs it too - without the flag, 2.14 dies with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Bug Fixes
 
 - **galaxy**: Add role READMEs so the collection imports
-  ([`b440894`](https://github.com/matonb/step/commit/b440894030d292d5dac8d9cac091aa3b361f03b0))
+  ([`b440894`](https://github.com/matonb/smallstep/commit/b440894030d292d5dac8d9cac091aa3b361f03b0))
 
 
 ## v1.4.0 (2026-08-10)
@@ -15,18 +15,18 @@
 ### Documentation
 
 - **requirements**: State the managed node Python floor as 3.9
-  ([#53](https://github.com/matonb/step/pull/53),
-  [`0c3bc96`](https://github.com/matonb/step/commit/0c3bc96d8eeedd881ce8e3d2f37972aa1e905f0f))
+  ([#53](https://github.com/matonb/smallstep/pull/53),
+  [`0c3bc96`](https://github.com/matonb/smallstep/commit/0c3bc96d8eeedd881ce8e3d2f37972aa1e905f0f))
 
 ### Features
 
 - **release**: Publish the collection to Ansible Galaxy
-  ([`77395ef`](https://github.com/matonb/step/commit/77395efb0a6394f27f14245ac59b144c00e7e87c))
+  ([`77395ef`](https://github.com/matonb/smallstep/commit/77395efb0a6394f27f14245ac59b144c00e7e87c))
 
 ### Testing
 
-- **unit**: Lift run_module into a conftest fixture ([#54](https://github.com/matonb/step/pull/54),
-  [`3e30bf8`](https://github.com/matonb/step/commit/3e30bf83873c2688a41e2c451b2b49a1759935bc))
+- **unit**: Lift run_module into a conftest fixture ([#54](https://github.com/matonb/smallstep/pull/54),
+  [`3e30bf8`](https://github.com/matonb/smallstep/commit/3e30bf83873c2688a41e2c451b2b49a1759935bc))
 
 
 ## v1.3.3 (2026-08-09)
@@ -34,13 +34,13 @@
 ### Bug Fixes
 
 - **tests**: Give root a read bit on /etc/shadow in the redhat image
-  ([#52](https://github.com/matonb/step/pull/52),
-  [`0fb267b`](https://github.com/matonb/step/commit/0fb267b5a3f5af069a4c1bdf5618ad74420fdbef))
+  ([#52](https://github.com/matonb/smallstep/pull/52),
+  [`0fb267b`](https://github.com/matonb/smallstep/commit/0fb267b5a3f5af069a4c1bdf5618ad74420fdbef))
 
 ### Testing
 
 - **integration**: Merge connection options via YAML anchor
-  ([`d34fef7`](https://github.com/matonb/step/commit/d34fef7d3e4de9cbc4b42863a5405f9227f5ece7))
+  ([`d34fef7`](https://github.com/matonb/smallstep/commit/d34fef7d3e4de9cbc4b42863a5405f9227f5ece7))
 
 
 ## v1.3.2 (2026-08-09)
@@ -48,21 +48,21 @@
 ### Bug Fixes
 
 - **tests**: Run the config CA as the user running the suite
-  ([`7f476dc`](https://github.com/matonb/step/commit/7f476dc90a1edf7d99286374cdd45adfa1e9bccf))
+  ([`7f476dc`](https://github.com/matonb/smallstep/commit/7f476dc90a1edf7d99286374cdd45adfa1e9bccf))
 
 - **tests**: Stop role.sh hiding every other collection
-  ([`7e013ae`](https://github.com/matonb/step/commit/7e013ae2db3fe7262f56792aa467eac5665cf291))
+  ([`7e013ae`](https://github.com/matonb/smallstep/commit/7e013ae2db3fe7262f56792aa467eac5665cf291))
 
 ### Continuous Integration
 
 - **workflow**: Install community.general for the role suite
-  ([`6a06a54`](https://github.com/matonb/step/commit/6a06a546ea646eec845b7eccc615e1a0c187008b))
+  ([`6a06a54`](https://github.com/matonb/smallstep/commit/6a06a546ea646eec845b7eccc615e1a0c187008b))
 
 - **workflow**: Run the integration suites on a label and on demand
-  ([`da94f7d`](https://github.com/matonb/step/commit/da94f7d080ee8bdb6c3f16b65f5f26d98d28614a))
+  ([`da94f7d`](https://github.com/matonb/smallstep/commit/da94f7d080ee8bdb6c3f16b65f5f26d98d28614a))
 
 - **workflow**: Test the floor of the supported range too
-  ([`4860616`](https://github.com/matonb/step/commit/486061654eee8480f012f4289ceba3a93a16c80f))
+  ([`4860616`](https://github.com/matonb/smallstep/commit/486061654eee8480f012f4289ceba3a93a16c80f))
 
 
 ## v1.3.1 (2026-08-08)
@@ -70,40 +70,40 @@
 ### Bug Fixes
 
 - **process**: Drop supplementary groups when demoting
-  ([`d475dde`](https://github.com/matonb/step/commit/d475ddefb18596fa86b96125967c97f02d154aa2))
+  ([`d475dde`](https://github.com/matonb/smallstep/commit/d475ddefb18596fa86b96125967c97f02d154aa2))
 
 - **process**: Install a preexec_fn only when demoting
-  ([`d50137c`](https://github.com/matonb/step/commit/d50137cde6029480274ade8a4a72c48cd8349ed1))
+  ([`d50137c`](https://github.com/matonb/smallstep/commit/d50137cde6029480274ade8a4a72c48cd8349ed1))
 
 - **process**: Resolve the demotion before forking
-  ([`326eed4`](https://github.com/matonb/step/commit/326eed46dff84a0e84b80562cd9b789b3a4d060a))
+  ([`326eed4`](https://github.com/matonb/smallstep/commit/326eed46dff84a0e84b80562cd9b789b3a4d060a))
 
 ### Continuous Integration
 
 - **pre-commit**: Pin shellcheck to the version CI runs
-  ([`98b5bf7`](https://github.com/matonb/step/commit/98b5bf76070641cbb947dab95520f14fe0af684b))
+  ([`98b5bf7`](https://github.com/matonb/smallstep/commit/98b5bf76070641cbb947dab95520f14fe0af684b))
 
 - **workflow**: Pin the sanity runner so shellcheck stays paired
-  ([`90c8274`](https://github.com/matonb/step/commit/90c827420c97cd37e9d281b0ed4b262d8a89e3c3))
+  ([`90c8274`](https://github.com/matonb/smallstep/commit/90c827420c97cd37e9d281b0ed4b262d8a89e3c3))
 
 ### Refactoring
 
 - **process**: Delete the unreachable failure handler
-  ([`753aba0`](https://github.com/matonb/step/commit/753aba0406508962bd0bd152cfc4ae945bccfebc))
+  ([`753aba0`](https://github.com/matonb/smallstep/commit/753aba0406508962bd0bd152cfc4ae945bccfebc))
 
 - **process**: Remove the second unreachable handler
-  ([`5649305`](https://github.com/matonb/step/commit/564930563853c638831cb36d97629a90e46e164a))
+  ([`5649305`](https://github.com/matonb/smallstep/commit/564930563853c638831cb36d97629a90e46e164a))
 
 ### Testing
 
 - **process**: Assert the demotion hook reaches subprocess
-  ([`190bad7`](https://github.com/matonb/step/commit/190bad7c6e19e6f904f2de93c97a09438bae337d))
+  ([`190bad7`](https://github.com/matonb/smallstep/commit/190bad7c6e19e6f904f2de93c97a09438bae337d))
 
 - **process**: Cover demotion, the timeout path and the helpers
-  ([`8dfc9ca`](https://github.com/matonb/step/commit/8dfc9caf160f5f205602fb6a3500d87cdc4509e3))
+  ([`8dfc9ca`](https://github.com/matonb/smallstep/commit/8dfc9caf160f5f205602fb6a3500d87cdc4509e3))
 
 - **process**: Cover the group lookup failing
-  ([`95542a0`](https://github.com/matonb/step/commit/95542a03270100a0ab06818d6f477314442950be))
+  ([`95542a0`](https://github.com/matonb/smallstep/commit/95542a03270100a0ab06818d6f477314442950be))
 
 
 ## v1.3.0 (2026-08-08)
@@ -111,111 +111,111 @@
 ### Bug Fixes
 
 - **ca_server**: Manage the step-ca service lifecycle
-  ([`a4b6af6`](https://github.com/matonb/step/commit/a4b6af6d7f460f3d67327e352614dceccc923416))
+  ([`a4b6af6`](https://github.com/matonb/smallstep/commit/a4b6af6d7f460f3d67327e352614dceccc923416))
 
 - **ca_server**: Report on step-ca with an unmanaged repository
-  ([`088add6`](https://github.com/matonb/step/commit/088add6ea3c5ee421e12a986daa56c257070f26a))
+  ([`088add6`](https://github.com/matonb/smallstep/commit/088add6ea3c5ee421e12a986daa56c257070f26a))
 
 - **initialize**: Report ok when the CA is already initialized
-  ([`45eabcc`](https://github.com/matonb/step/commit/45eabccf9d64f475347bdbcbe377da6d666c2eb9))
+  ([`45eabcc`](https://github.com/matonb/smallstep/commit/45eabccf9d64f475347bdbcbe377da6d666c2eb9))
 
 - **meta**: Require ansible-core 2.14
-  ([`6bbaf01`](https://github.com/matonb/step/commit/6bbaf01eefc0a626c6a7e74d552fd2f5c4b2a86c))
+  ([`6bbaf01`](https://github.com/matonb/smallstep/commit/6bbaf01eefc0a626c6a7e74d552fd2f5c4b2a86c))
 
 - **step_cli**: Refresh the apt cache when the signing key changes
-  ([`10d5547`](https://github.com/matonb/step/commit/10d554707fc063c82725f809214833ac54a3dc2d))
+  ([`10d5547`](https://github.com/matonb/smallstep/commit/10d554707fc063c82725f809214833ac54a3dc2d))
 
 - **step_cli**: Reject either gpg switch on Debian, not just one
-  ([`c09e7b4`](https://github.com/matonb/step/commit/c09e7b447bff6614fe7880411675df9868887d42))
+  ([`c09e7b4`](https://github.com/matonb/smallstep/commit/c09e7b447bff6614fe7880411675df9868887d42))
 
 - **tests**: Read start_host's family from its argument
-  ([`e794317`](https://github.com/matonb/step/commit/e7943172fab644120977325eaf625fbf3277b9f6))
+  ([`e794317`](https://github.com/matonb/smallstep/commit/e7943172fab644120977325eaf625fbf3277b9f6))
 
 - **tests**: Write both guards as if-then for older shellcheck
-  ([`bbdf402`](https://github.com/matonb/step/commit/bbdf40247ddb1a5ead0d16552c057391293a0bb0))
+  ([`bbdf402`](https://github.com/matonb/smallstep/commit/bbdf40247ddb1a5ead0d16552c057391293a0bb0))
 
 ### Chores
 
 - **ca_bootstrap**: Remove the dead systemd unit template
-  ([`e7715e0`](https://github.com/matonb/step/commit/e7715e08683e0af157b19a01ffa7d9a7dda1eba5))
+  ([`e7715e0`](https://github.com/matonb/smallstep/commit/e7715e08683e0af157b19a01ffa7d9a7dda1eba5))
 
 ### Code Style
 
 - Use American English throughout
-  ([`60faeb2`](https://github.com/matonb/step/commit/60faeb25049948547d57c817079c12f5b8dbb025))
+  ([`60faeb2`](https://github.com/matonb/smallstep/commit/60faeb25049948547d57c817079c12f5b8dbb025))
 
 - **roles**: Fold the package name scalars
-  ([`342edc1`](https://github.com/matonb/step/commit/342edc10964e48dc5ce8ffeaa5d5a4a21f22a2f1))
+  ([`342edc1`](https://github.com/matonb/smallstep/commit/342edc10964e48dc5ce8ffeaa5d5a4a21f22a2f1))
 
 ### Continuous Integration
 
 - **pre-commit**: Run shellcheck locally as CI already does
-  ([`8e71e2b`](https://github.com/matonb/step/commit/8e71e2bf913522906f980ac99e293eb709de17ad))
+  ([`8e71e2b`](https://github.com/matonb/smallstep/commit/8e71e2bf913522906f980ac99e293eb709de17ad))
 
 ### Documentation
 
 - Describe the collection, its roles and how they are tested
-  ([`b3f1bf4`](https://github.com/matonb/step/commit/b3f1bf43650be5d567a9b8ab51b5dda1262b615c))
+  ([`b3f1bf4`](https://github.com/matonb/smallstep/commit/b3f1bf43650be5d567a9b8ab51b5dda1262b615c))
 
 - **roles**: Say what the gates test and what the defaults are
-  ([`a4b5bb2`](https://github.com/matonb/step/commit/a4b5bb2789c2c98caeb39b242a6b72f2ee21fbc5))
+  ([`a4b5bb2`](https://github.com/matonb/smallstep/commit/a4b5bb2789c2c98caeb39b242a6b72f2ee21fbc5))
 
 - **roles**: Stop describing an unpinned version as latest
-  ([`d5d18dc`](https://github.com/matonb/step/commit/d5d18dc760c14234ed85bdfee05eabfc01265aba))
+  ([`d5d18dc`](https://github.com/matonb/smallstep/commit/d5d18dc760c14234ed85bdfee05eabfc01265aba))
 
 - **step_cli**: Record why check mode differs between the families
-  ([`ec2eaf6`](https://github.com/matonb/step/commit/ec2eaf6cacc4bd97443548656298ce9826dcc243))
+  ([`ec2eaf6`](https://github.com/matonb/smallstep/commit/ec2eaf6cacc4bd97443548656298ce9826dcc243))
 
 - **tests**: Renumber the role.sh scenarios its documentation describes
-  ([`e931658`](https://github.com/matonb/step/commit/e931658a33893a40087e656547c02cb7e7f31555))
+  ([`e931658`](https://github.com/matonb/smallstep/commit/e931658a33893a40087e656547c02cb7e7f31555))
 
 ### Features
 
 - **roles**: Define the variables the roles need to run
-  ([`f2ce6d7`](https://github.com/matonb/step/commit/f2ce6d7726f24e4bf98d6a117f610505feec307c))
+  ([`f2ce6d7`](https://github.com/matonb/smallstep/commit/f2ce6d7726f24e4bf98d6a117f610505feec307c))
 
 - **roles**: Install from smallstep's package repositories
-  ([`aeee7de`](https://github.com/matonb/step/commit/aeee7de2a0e37a155611902917ad4f960993c09c))
+  ([`aeee7de`](https://github.com/matonb/smallstep/commit/aeee7de2a0e37a155611902917ad4f960993c09c))
 
 ### Refactoring
 
 - **ca_server**: Drop the refresh its dependency already does
-  ([`8f07c99`](https://github.com/matonb/step/commit/8f07c99d00e67716cd4c4651e03c5a35c79abd2b))
+  ([`8f07c99`](https://github.com/matonb/smallstep/commit/8f07c99d00e67716cd4c4651e03c5a35c79abd2b))
 
 - **ca_server**: Share one version separator, and pin both roles
-  ([`384e788`](https://github.com/matonb/step/commit/384e7884c5b34fd06609b9333fc3f69c3f0f1eef))
+  ([`384e788`](https://github.com/matonb/smallstep/commit/384e7884c5b34fd06609b9333fc3f69c3f0f1eef))
 
 - **roles**: Derive the repository paths from one name
-  ([`f96b9bd`](https://github.com/matonb/step/commit/f96b9bdee3cad02b8fb8a9af3ff57eafea51c3b9))
+  ([`f96b9bd`](https://github.com/matonb/smallstep/commit/f96b9bdee3cad02b8fb8a9af3ff57eafea51c3b9))
 
 ### Testing
 
 - **roles**: Ask each package manager what it can actually answer
-  ([`c57962e`](https://github.com/matonb/step/commit/c57962ee5eb059eefbf5a095e9a5930225974a93))
+  ([`c57962e`](https://github.com/matonb/smallstep/commit/c57962ee5eb059eefbf5a095e9a5930225974a93))
 
 - **roles**: Assert check mode leaves the repository alone
-  ([`c22f10a`](https://github.com/matonb/step/commit/c22f10aa191e43601f2b734f9d9776a12792bb26))
+  ([`c22f10a`](https://github.com/matonb/smallstep/commit/c22f10aa191e43601f2b734f9d9776a12792bb26))
 
 - **roles**: Cover a repository the roles do not manage
-  ([`3b1918d`](https://github.com/matonb/step/commit/3b1918dbce63c4d117ea073b6dff2ff74d620b6b))
+  ([`3b1918d`](https://github.com/matonb/smallstep/commit/3b1918dbce63c4d117ea073b6dff2ff74d620b6b))
 
 - **roles**: Drive ca_server against real systemd containers
-  ([`8bd12d3`](https://github.com/matonb/step/commit/8bd12d3c97f0f52d46b52581cbf072624fcc95cd))
+  ([`8bd12d3`](https://github.com/matonb/smallstep/commit/8bd12d3c97f0f52d46b52581cbf072624fcc95cd))
 
 - **roles**: Exercise version pinning against a real package manager
-  ([`895cf6f`](https://github.com/matonb/step/commit/895cf6ffca110189167ae4063a4554d26695d605))
+  ([`895cf6f`](https://github.com/matonb/smallstep/commit/895cf6ffca110189167ae4063a4554d26695d605))
 
 - **roles**: Let the repository assertion reach its own error message
-  ([`6563f4b`](https://github.com/matonb/step/commit/6563f4ba39edc75fc47a10c6866648bd07957e9c))
+  ([`6563f4b`](https://github.com/matonb/smallstep/commit/6563f4ba39edc75fc47a10c6866648bd07957e9c))
 
 - **roles**: Let the suite say why it could not read the roles
-  ([`175bb57`](https://github.com/matonb/step/commit/175bb57ffb8cedeeb011be70f42341c972e9ac03))
+  ([`175bb57`](https://github.com/matonb/smallstep/commit/175bb57ffb8cedeeb011be70f42341c972e9ac03))
 
 - **roles**: Pin RedHat by the version form the docs describe
-  ([`15071a3`](https://github.com/matonb/step/commit/15071a3eb0c7efa0ce32c0bc31fbe0c513f3ec66))
+  ([`15071a3`](https://github.com/matonb/smallstep/commit/15071a3eb0c7efa0ce32c0bc31fbe0c513f3ec66))
 
 - **roles**: Say which failure the pin scenarios expect
-  ([`8b50fbf`](https://github.com/matonb/step/commit/8b50fbfd8fc98b0105264246b6354bc2f28ac90e))
+  ([`8b50fbf`](https://github.com/matonb/smallstep/commit/8b50fbfd8fc98b0105264246b6354bc2f28ac90e))
 
 
 ## v1.2.0 (2026-08-05)
@@ -223,8 +223,8 @@
 ### Features
 
 - **configure**: Write ca.json atomically via the shared helpers
-  ([#45](https://github.com/matonb/step/pull/45),
-  [`220b18c`](https://github.com/matonb/step/commit/220b18c21a01b8482b243653df260e0605906d66))
+  ([#45](https://github.com/matonb/smallstep/pull/45),
+  [`220b18c`](https://github.com/matonb/smallstep/commit/220b18c21a01b8482b243653df260e0605906d66))
 
 
 ## v1.1.3 (2026-08-05)
@@ -232,8 +232,8 @@
 ### Bug Fixes
 
 - **initialize**: Never delete the CA during a check-mode run
-  ([#43](https://github.com/matonb/step/pull/43),
-  [`d79bd90`](https://github.com/matonb/step/commit/d79bd906f27f94c5cdff1ea806d025bea24cf7ab))
+  ([#43](https://github.com/matonb/smallstep/pull/43),
+  [`d79bd90`](https://github.com/matonb/smallstep/commit/d79bd906f27f94c5cdff1ea806d025bea24cf7ab))
 
 
 ## v1.1.2 (2026-08-05)
@@ -241,8 +241,8 @@
 ### Bug Fixes
 
 - **configure**: Report changed accurately and declare dependency
-  ([#34](https://github.com/matonb/step/pull/34),
-  [`61ea949`](https://github.com/matonb/step/commit/61ea949d6db57cc328ceb71e46c378f6c0286f29))
+  ([#34](https://github.com/matonb/smallstep/pull/34),
+  [`61ea949`](https://github.com/matonb/smallstep/commit/61ea949d6db57cc328ceb71e46c378f6c0286f29))
 
 
 ## v1.1.1 (2026-08-05)
@@ -250,14 +250,14 @@
 ### Bug Fixes
 
 - **provisioner**: Read provisioners from ca.json in config mode
-  ([#33](https://github.com/matonb/step/pull/33),
-  [`083a024`](https://github.com/matonb/step/commit/083a024b708b16e82766df4a6df995cc0045edde))
+  ([#33](https://github.com/matonb/smallstep/pull/33),
+  [`083a024`](https://github.com/matonb/smallstep/commit/083a024b708b16e82766df4a6df995cc0045edde))
 
 ### Documentation
 
 - **examples**: Add example playbooks for provisioner management
-  ([#33](https://github.com/matonb/step/pull/33),
-  [`083a024`](https://github.com/matonb/step/commit/083a024b708b16e82766df4a6df995cc0045edde))
+  ([#33](https://github.com/matonb/smallstep/pull/33),
+  [`083a024`](https://github.com/matonb/smallstep/commit/083a024b708b16e82766df4a6df995cc0045edde))
 
 
 ## v1.1.0 (2026-08-04)
@@ -265,25 +265,25 @@
 ### Chores
 
 - Replace placeholder collection metadata
-  ([`e7f9204`](https://github.com/matonb/step/commit/e7f92042887eadc5c17d3f509ee34524ca0c4452))
+  ([`e7f9204`](https://github.com/matonb/smallstep/commit/e7f92042887eadc5c17d3f509ee34524ca0c4452))
 
 ### Continuous Integration
 
 - Bump actions to current majors and Node 24
-  ([`991cc26`](https://github.com/matonb/step/commit/991cc26d5fbc2321634430d9d3cd22fa3231e41a))
+  ([`991cc26`](https://github.com/matonb/smallstep/commit/991cc26d5fbc2321634430d9d3cd22fa3231e41a))
 
 - **lint**: Run ruff and yamllint through pre-commit
-  ([`ede111f`](https://github.com/matonb/step/commit/ede111fcd2e709898324d2d565775b5e536414da))
+  ([`ede111f`](https://github.com/matonb/smallstep/commit/ede111fcd2e709898324d2d565775b5e536414da))
 
 ### Features
 
 - **provisioner**: Support step-ca admin mode deployments
-  ([`e024d47`](https://github.com/matonb/step/commit/e024d472a3fa22a5e3689b25fdca86956423fe5c))
+  ([`e024d47`](https://github.com/matonb/smallstep/commit/e024d472a3fa22a5e3689b25fdca86956423fe5c))
 
 ### Testing
 
 - Add unit and integration suites with CI gating
-  ([`283af77`](https://github.com/matonb/step/commit/283af7748ff08c7d5bfc945e0594438f7e02d9cc))
+  ([`283af77`](https://github.com/matonb/smallstep/commit/283af7748ff08c7d5bfc945e0594438f7e02d9cc))
 
 
 ## v1.0.1 (2026-07-29)
@@ -291,12 +291,12 @@
 ### Bug Fixes
 
 - **provisioner**: Honour check mode and allow type-less present
-  ([`adcff09`](https://github.com/matonb/step/commit/adcff09295cb50ac86f04dc782728483c9007bc7))
+  ([`adcff09`](https://github.com/matonb/smallstep/commit/adcff09295cb50ac86f04dc782728483c9007bc7))
 
 ### Code Style
 
 - **docs**: Reformat run_command example in module_utils README
-  ([`bdb0f96`](https://github.com/matonb/step/commit/bdb0f96959092c7b903842d0a060f2cf51f794f6))
+  ([`bdb0f96`](https://github.com/matonb/smallstep/commit/bdb0f96959092c7b903842d0a060f2cf51f794f6))
 
 
 ## v1.0.0 (2026-06-16)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Step CA Ansible Collection
 
+[![Release](https://github.com/matonb/smallstep/actions/workflows/release.yml/badge.svg?branch=main)](https://github.com/matonb/smallstep/actions/workflows/release.yml)
+[![License: GPL-3.0-or-later](https://img.shields.io/badge/License-GPL--3.0--or--later-blue.svg)](LICENSE)
+
 Ansible collection for installing and managing a [Step CA](https://smallstep.com/docs/step-ca) certificate authority.
 
 ## Description
@@ -16,7 +19,7 @@ including against a CA that is not running.
 | module `initialize`            | Create the CA, idempotently                                            |
 | module `configure`             | Edit `ca.json` — paths, database, certificate duration claims          |
 | module `provisioner`           | Create, update and remove provisioners                                 |
-| module `bootstrap`             | Read a step-ca JSON configuration file, such as `defaults.json`        |
+| module `config_info`           | Read a step-ca JSON configuration file, such as `defaults.json`        |
 
 ## Requirements
 
@@ -35,7 +38,7 @@ including against a CA that is not running.
 
 ---
 
-## matonb.step.configure
+## matonb.smallstep.configure
 
 Modify Step CA configuration JSON file (ca.json). Supports top-level parameters and certificate duration claims.
 
@@ -88,7 +91,7 @@ both `config/ca.json` and the password file exist, which the unit requires.
 ```yaml
 # Set certificate duration limits
 - name: Configure certificate durations
-  matonb.step.configure:
+  matonb.smallstep.configure:
     default_tls_cert_duration: "720h" # 30 days
     json_path: /etc/step-ca/config/ca.json
     max_tls_cert_duration: "8760h" # 1 year
@@ -96,13 +99,13 @@ both `config/ca.json` and the password file exist, which the unit requires.
 
 # Update database path
 - name: Configure database
-  matonb.step.configure:
+  matonb.smallstep.configure:
     db_datasource: /var/lib/step-ca/db
     json_path: /etc/step-ca/config/ca.json
 
 # Configure multiple settings
 - name: Configure paths and durations
-  matonb.step.configure:
+  matonb.smallstep.configure:
     crt: /etc/step-ca/certs/intermediate_ca.crt
     json_path: /etc/step-ca/config/ca.json
     key: /etc/step-ca/secrets/intermediate_ca_key
@@ -112,7 +115,7 @@ both `config/ca.json` and the password file exist, which the unit requires.
 
 ---
 
-## matonb.step.provisioner
+## matonb.smallstep.provisioner
 
 Creates, updates and removes provisioners. Works against both management modes —
 see [Management modes](#management-modes) below.
@@ -196,7 +199,7 @@ required:
 
 ```yaml
 - name: Manage a provisioner on an admin-mode CA
-  matonb.step.provisioner:
+  matonb.smallstep.provisioner:
     admin_password_file: /etc/step-ca/secrets/provisioner_password
     admin_provisioner: admin        # a JWK provisioner the admin is bound to
     admin_subject: step             # the super admin created at init time
@@ -211,7 +214,7 @@ required:
 
 ```yaml
 - name: Manage a provisioner with an admin certificate
-  matonb.step.provisioner:
+  matonb.smallstep.provisioner:
     admin_cert: /etc/step-ca/admin.crt
     admin_key: /etc/step-ca/admin.key
     ca_path: /etc/step-ca
@@ -245,8 +248,8 @@ that matters to you.
 
 ### Upgrading from 1.1.x
 
-Two changes to `matonb.step.configure`, both closing
-[#37](https://github.com/matonb/step/issues/37):
+Two changes to `matonb.smallstep.configure`, both closing
+[#37](https://github.com/matonb/smallstep/issues/37):
 
 - **A missing `json_path` now fails** rather than creating a new file. Set
   `create: true` if a task genuinely builds a configuration from nothing.
@@ -254,7 +257,7 @@ Two changes to `matonb.step.configure`, both closing
   `ca_path` and `ca_config` beside it were `path`. The two combined badly: a
   `~/step-ca/config/ca.json` produced a literal `~` directory.
 
-Then, for `matonb.step.provisioner`:
+Then, for `matonb.smallstep.provisioner`:
 
 **`ca_path` or `ca_config` is now required, unless you set
 `management_mode: admin`.** Two things that used to work by reaching the CA over
@@ -265,7 +268,7 @@ So does a task whose `ca_path` does not actually contain `config/ca.json` — th
 containerised case, where `defaults.json` points `ca-config` somewhere else — or
 whose `ca.json` the module cannot read because it runs without `become`.
 
-This closes a real bug ([#31](https://github.com/matonb/step/issues/31)): in
+This closes a real bug ([#31](https://github.com/matonb/smallstep/issues/31)): in
 config mode the module read provisioners from the CA's *loaded* configuration
 while writing them to `ca.json`, so re-running a play before step-ca had been
 reloaded failed with `provisioner with name acme already exists`. Reading the
@@ -341,7 +344,7 @@ Complete, runnable playbooks live in [`examples/`](examples/).
 
 ```yaml
 - name: Create JWK provisioner
-  matonb.step.provisioner:
+  matonb.smallstep.provisioner:
     ca_path: /etc/step-ca
     name: my-jwk-provisioner
     run_as: step # Run as step user for proper CA access
@@ -368,7 +371,7 @@ adds several provisioners then reloads once, at the end.
 
 ```yaml
 - name: Remove provisioner
-  matonb.step.provisioner:
+  matonb.smallstep.provisioner:
     ca_path: /etc/step-ca
     name: old-provisioner
     run_as: step
@@ -395,7 +398,7 @@ without making it — `changed` is `false` when the provisioner already matches.
 
 ```yaml
 - name: Check whether the provisioner exists
-  matonb.step.provisioner:
+  matonb.smallstep.provisioner:
     ca_path: /etc/step-ca
     name: my-provisioner
     run_as: step
@@ -419,7 +422,7 @@ step refuses.
 
 ---
 
-## matonb.step.initialize
+## matonb.smallstep.initialize
 
 Running against a CA that is already there reports `ok` and changes nothing, so
 a play containing the task can be re-run.
@@ -443,7 +446,7 @@ half-built.
 `config/defaults.json` is deliberately not part of the test. step-ca itself is
 started with `ca.json` and never reads it, so a CA without it is initialized and
 working. It is not worthless though — it carries the `ca_url` and `root`
-defaults the `step` CLI and `matonb.step.provisioner` fall back on — so a CA
+defaults the `step` CLI and `matonb.smallstep.provisioner` fall back on — so a CA
 reported `ok` without it can still fail a later task that relies on those.
 Restore the file; do not reinitialize the CA for it.
 
@@ -474,16 +477,16 @@ irrecoverably.
 
 ## Roles
 
-### matonb.step.ca_server
+### matonb.smallstep.ca_server
 
 Installs step-ca, creates the `step` user, grants the binary
 `CAP_NET_BIND_SERVICE` so it can bind 443 without running as root, templates a
 sandboxed systemd unit, and manages the service.
 
-**It depends on `matonb.step.step_cli`**, which Ansible runs first. That role
+**It depends on `matonb.smallstep.step_cli`**, which Ansible runs first. That role
 owns the smallstep repository and the step CLI, so including `ca_server` alone
 still gives you a host that can initialize and manage its own CA —
-`matonb.step.initialize` shells out to `step ca init`. Configure the repository
+`matonb.smallstep.initialize` shells out to `step ca init`. Configure the repository
 through `step_cli`'s variables, below; there is deliberately only one set.
 
 | Variable                    | Default                     | Description                                                                       |
@@ -498,7 +501,7 @@ through `step_cli`'s variables, below; there is deliberately only one set.
 the key to the CA. Until it exists and is non-empty, the service will not start,
 and it must be readable by the `step` user, since that is who step-ca runs as.
 
-### matonb.step.step_cli
+### matonb.smallstep.step_cli
 
 Installs the step CLI, and owns the smallstep repository both roles install
 from. Use it directly on hosts that talk to a CA rather than run one;
@@ -609,7 +612,7 @@ reports drift on everything thereafter.
 - name: Build a CA
   hosts: ca
   roles:
-    - matonb.step.ca_server
+    - matonb.smallstep.ca_server
 
   tasks:
     - name: Install the CA password
@@ -624,7 +627,7 @@ reports drift on everything thereafter.
     - name: Initialize the CA
       become: true
       become_user: step
-      matonb.step.initialize:
+      matonb.smallstep.initialize:
         name: Example CA
         path: /etc/step-ca
         dns: [ca.example.com]

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,6 +1,6 @@
 # Examples
 
-Example playbooks for `matonb.step`. They are written to be read, not run
+Example playbooks for `matonb.smallstep`. They are written to be read, not run
 unmodified: every one targets a `step_ca` inventory group and assumes the CA
 lives at `/etc/step-ca` owned by the `step` user. Change the `vars` block to
 match your deployment.
@@ -34,9 +34,9 @@ changes go through the Admin API and are live immediately, so
 `restart_required` is always `false`.
 
 Running these needs the collection installed, or a checkout reachable under an
-`ansible_collections/matonb/step` path:
+`ansible_collections/matonb/smallstep` path:
 
 ```console
-$ ansible-galaxy collection install matonb.step
+$ ansible-galaxy collection install matonb.smallstep
 $ ansible-playbook -i inventory.ini examples/provisioner_config_mode.yml
 ```

--- a/examples/provisioner_admin_mode.yml
+++ b/examples/provisioner_admin_mode.yml
@@ -25,7 +25,7 @@
     # for admin_subject using admin_provisioner. This is what
     # `step ca init --remote-management` sets up.
     - name: Add an ACME provisioner
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         admin_password_file: /etc/step-ca/secrets/provisioner_password
         admin_provisioner: admin
         admin_subject: step
@@ -50,7 +50,7 @@
     # and key you already hold. The key must not be encrypted - step loads it
     # without a password option and would prompt.
     - name: Add a JWK provisioner using an existing admin certificate
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         admin_cert: /etc/step-ca/admin/admin.crt
         admin_key: /etc/step-ca/admin/admin.key
         ca_path: "{{ step_ca_path }}"

--- a/examples/provisioner_config_mode.yml
+++ b/examples/provisioner_config_mode.yml
@@ -27,7 +27,7 @@
 
   tasks:
     - name: Add an ACME provisioner
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         ca_path: "{{ step_ca_path }}"
         name: acme
         run_as: "{{ step_ca_user }}"
@@ -35,7 +35,7 @@
       notify: Reload step-ca
 
     - name: Add a JWK provisioner for CI
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         ca_path: "{{ step_ca_path }}"
         name: cicd
         run_as: "{{ step_ca_user }}"
@@ -57,7 +57,7 @@
       when: cicd_provisioner.generated_password is defined
 
     - name: Retire an old provisioner
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         ca_path: "{{ step_ca_path }}"
         name: legacy
         run_as: "{{ step_ca_user }}"

--- a/examples/provisioner_reconcile.yml
+++ b/examples/provisioner_reconcile.yml
@@ -36,7 +36,7 @@
 
   tasks:
     - name: Apply the certificate duration policy
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         ca_path: "{{ step_ca_path }}"
         name: "{{ item.name }}"
         run_as: "{{ step_ca_user }}"
@@ -62,7 +62,7 @@
     # ca.json, the same file it writes. A second run before the reload is
     # correctly a no-op.
     - name: Confirm a repeat run changes nothing
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         ca_path: "{{ step_ca_path }}"
         name: "{{ step_provisioners[0].name }}"
         run_as: "{{ step_ca_user }}"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@
 namespace: matonb
 
 # The name of the collection. Has the same character restrictions as 'namespace'
-name: step
+name: smallstep
 
 # The version of the collection. Must be compatible with semantic versioning
 version: 1.4.1
@@ -56,10 +56,10 @@ dependencies:
   community.general: '>=1.0.0'
 
 # Metadata URLs (optional but helpful)
-repository: https://github.com/matonb/step
-documentation: https://github.com/matonb/step/blob/main/README.md
-homepage: https://github.com/matonb/step
-issues: https://github.com/matonb/step/issues
+repository: https://github.com/matonb/smallstep
+documentation: https://github.com/matonb/smallstep/blob/main/README.md
+homepage: https://github.com/matonb/smallstep
+issues: https://github.com/matonb/smallstep/issues
 
 # List of file patterns to exclude from collection build artifact
 #

--- a/plugins/module_utils/utils.py
+++ b/plugins/module_utils/utils.py
@@ -242,7 +242,7 @@ def save_json_file(module, json_path: str, data: dict[str, Any]) -> Optional[str
     target = os.path.realpath(json_path)
     directory = os.path.dirname(target) or "."
     try:
-        handle, temporary = tempfile.mkstemp(dir=directory, prefix=".matonb-step-", suffix=".json")
+        handle, temporary = tempfile.mkstemp(dir=directory, prefix=".matonb-smallstep-", suffix=".json")
     except OSError as error:
         return f"Failed to write JSON file '{target}': {error}"
 

--- a/plugins/modules/config_info.py
+++ b/plugins/modules/config_info.py
@@ -6,7 +6,7 @@ DOCUMENTATION = r"""
 ---
 module: config_info
 short_description: Read a step-ca JSON configuration file
-version_added: "1.4.2"
+version_added: "1.0.0"
 description:
   - Reads a step-ca JSON configuration file, such as C(defaults.json), and returns its contents.
   - >-

--- a/plugins/modules/config_info.py
+++ b/plugins/modules/config_info.py
@@ -4,9 +4,9 @@
 
 DOCUMENTATION = r"""
 ---
-module: bootstrap
+module: config_info
 short_description: Read a step-ca JSON configuration file
-version_added: "1.0.0"
+version_added: "1.4.2"
 description:
   - Reads a step-ca JSON configuration file, such as C(defaults.json), and returns its contents.
   - >-
@@ -24,7 +24,7 @@ author:
 
 EXAMPLES = r"""
 - name: Read the CA defaults
-  matonb.step.bootstrap:
+  matonb.smallstep.config_info:
     config_file: /etc/step-ca/config/defaults.json
   register: ca_defaults
 
@@ -47,7 +47,7 @@ config:
 
 from ansible.module_utils.basic import AnsibleModule
 
-from ansible_collections.matonb.step.plugins.module_utils.utils import (
+from ansible_collections.matonb.smallstep.plugins.module_utils.utils import (
     read_json_file,
 )
 

--- a/plugins/modules/configure.py
+++ b/plugins/modules/configure.py
@@ -119,20 +119,20 @@ author:
 
 EXAMPLES = r"""
 - name: Configure certificate durations
-  matonb.step.configure:
+  matonb.smallstep.configure:
     default_tls_cert_duration: "720h"
     json_path: /etc/step-ca/config/ca.json
     max_tls_cert_duration: "8760h"
   notify: Reload step-ca
 
 - name: Configure the database datasource
-  matonb.step.configure:
+  matonb.smallstep.configure:
     db_datasource: /var/lib/step-ca/db
     json_path: /etc/step-ca/config/ca.json
   notify: Reload step-ca
 
 - name: Configure paths and durations together
-  matonb.step.configure:
+  matonb.smallstep.configure:
     crt: /etc/step-ca/certs/intermediate_ca.crt
     json_path: /etc/step-ca/config/ca.json
     key: /etc/step-ca/secrets/intermediate_ca_key
@@ -169,7 +169,7 @@ import os
 
 from ansible.module_utils.basic import AnsibleModule
 
-from ansible_collections.matonb.step.plugins.module_utils.utils import (
+from ansible_collections.matonb.smallstep.plugins.module_utils.utils import (
     parse_duration,
     read_json_file,
     save_json_file,

--- a/plugins/modules/initialize.py
+++ b/plugins/modules/initialize.py
@@ -33,7 +33,7 @@ description:
     C(config/defaults.json) is not part of that test. step-ca is started with
     C(ca.json) and never reads it, so a CA without it is initialized and
     working. It is not worthless, though - it carries the defaults the step CLI
-    and M(matonb.step.provisioner) fall back on for C(ca_url) and C(root) - so
+    and M(matonb.smallstep.provisioner) fall back on for C(ca_url) and C(root) - so
     a CA reported C(ok) without it can still fail a later task that relies on
     those. Restore the file; do not reinitialize the CA for it.
   - >-
@@ -257,14 +257,14 @@ author:
 
 EXAMPLES = r"""
 - name: Initialize a standalone Step CA
-  matonb.step.initialize:
+  matonb.smallstep.initialize:
     name: "My CA"
     path: "/etc/step-ca"
     password_file: "/path/to/password"
     provisioner_password_file: "/path/to/provisioner_password"
 
 - name: Initialize a Step CA with remote management (admin mode)
-  matonb.step.initialize:
+  matonb.smallstep.initialize:
     admin_subject: step
     name: "My CA"
     path: "/etc/step-ca"
@@ -320,12 +320,12 @@ from typing import Any, Optional
 
 from ansible.module_utils.basic import AnsibleModule
 
-from ansible_collections.matonb.step.plugins.module_utils.connection import read_authority
-from ansible_collections.matonb.step.plugins.module_utils.process import (
+from ansible_collections.matonb.smallstep.plugins.module_utils.connection import read_authority
+from ansible_collections.matonb.smallstep.plugins.module_utils.process import (
     CommandTimeoutError,
     run_command,
 )
-from ansible_collections.matonb.step.plugins.module_utils.utils import read_json_file
+from ansible_collections.matonb.smallstep.plugins.module_utils.utils import read_json_file
 
 # The files `step ca init` creates. Two jobs only: telling an empty directory
 # from one holding something, and naming what `force` deletes. Whether a CA is

--- a/plugins/modules/provisioner.py
+++ b/plugins/modules/provisioner.py
@@ -215,7 +215,7 @@ author:
 
 EXAMPLES = r"""
 - name: Add an ACME provisioner to a ca.json-managed CA
-  matonb.step.provisioner:
+  matonb.smallstep.provisioner:
     ca_path: /etc/step-ca
     name: acme
     run_as: step
@@ -223,7 +223,7 @@ EXAMPLES = r"""
   notify: Reload step-ca
 
 - name: Add a JWK provisioner with certificate duration claims
-  matonb.step.provisioner:
+  matonb.smallstep.provisioner:
     ca_path: /etc/step-ca
     name: cicd
     run_as: step
@@ -234,7 +234,7 @@ EXAMPLES = r"""
   register: cicd_provisioner
 
 - name: Manage a provisioner on a remote-management (admin mode) CA
-  matonb.step.provisioner:
+  matonb.smallstep.provisioner:
     admin_password_file: /etc/step-ca/secrets/provisioner_password
     admin_provisioner: admin
     admin_subject: step
@@ -245,7 +245,7 @@ EXAMPLES = r"""
     type: ACME
 
 - name: Remove a provisioner
-  matonb.step.provisioner:
+  matonb.smallstep.provisioner:
     ca_path: /etc/step-ca
     name: acme
     run_as: step
@@ -310,22 +310,22 @@ from typing import Optional
 
 from ansible.module_utils.basic import AnsibleModule
 
-from ansible_collections.matonb.step.plugins.module_utils.connection import (
+from ansible_collections.matonb.smallstep.plugins.module_utils.connection import (
     AdminCredentials,
     ManagementMode,
     StepConnection,
     configured_mode,
     observed_mode,
 )
-from ansible_collections.matonb.step.plugins.module_utils.process import (
+from ansible_collections.matonb.smallstep.plugins.module_utils.process import (
     CommandTimeoutError,
 )
-from ansible_collections.matonb.step.plugins.module_utils.provisioner import (
+from ansible_collections.matonb.smallstep.plugins.module_utils.provisioner import (
     X509_CLAIMS,
     StepProvisionerClient,
     claim_drift,
 )
-from ansible_collections.matonb.step.plugins.module_utils.utils import PROMPT_PATTERN
+from ansible_collections.matonb.smallstep.plugins.module_utils.utils import PROMPT_PATTERN
 
 VALID_TYPES = [
     "JWK",
@@ -342,7 +342,7 @@ VALID_TYPES = [
 ]
 
 DEPRECATION_VERSION = "2.0.0"
-COLLECTION_NAME = "matonb.step"
+COLLECTION_NAME = "matonb.smallstep"
 
 
 def get_argument_spec() -> dict:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [{ name = "Brett Maton", email = "brett@example.com" }]
 description = "Ansible collection for managing Smallstep Certificate Authority"
 dynamic = ["version"]
 license = { text = "GPL-3.0-or-later" }
-name = "matonb.step"
+name = "matonb.smallstep"
 requires-python = ">=3.9"
 
 [project.optional-dependencies]
@@ -176,7 +176,7 @@ max-statements = 60
 convention = "google" # Use Google-style docstrings
 
 [tool.ruff.lint.isort]
-known-first-party = ["ansible_collections.matonb.step"]
+known-first-party = ["ansible_collections.matonb.smallstep"]
 
 [tool.semantic_release]
 build_command = ""

--- a/roles/ca_server/README.md
+++ b/roles/ca_server/README.md
@@ -1,13 +1,13 @@
-# matonb.step.ca_server
+# matonb.smallstep.ca_server
 
 Installs [step-ca](https://smallstep.com/docs/step-ca/), creates the `step`
 user, grants the binary `CAP_NET_BIND_SERVICE` so it can bind 443 without
 running as root, templates a sandboxed systemd unit, and manages the service.
 
-**It depends on `matonb.step.step_cli`**, which Ansible runs first. That role
-owns the smallstep package repository and the step CLI, so including
+**It depends on `matonb.smallstep.step_cli`**, which Ansible runs first. That
+role owns the smallstep package repository and the step CLI, so including
 `ca_server` alone still gives you a host that can initialize and manage its own
-CA — `matonb.step.initialize` shells out to `step ca init`. Configure the
+CA — `matonb.smallstep.initialize` shells out to `step ca init`. Configure the
 repository through `step_cli`'s variables; there is deliberately only one set.
 
 ## Requirements
@@ -81,7 +81,7 @@ what it would do.
 
 ## Dependencies
 
-- `matonb.step.step_cli`
+- `matonb.smallstep.step_cli`
 
 ## Example playbook
 
@@ -89,7 +89,7 @@ what it would do.
 - name: Build a CA
   hosts: ca
   roles:
-    - matonb.step.ca_server
+    - matonb.smallstep.ca_server
 
   tasks:
     - name: Install the CA password
@@ -104,7 +104,7 @@ what it would do.
     - name: Initialize the CA
       become: true
       become_user: step
-      matonb.step.initialize:
+      matonb.smallstep.initialize:
         name: Example CA
         path: /etc/step-ca
         dns: [ca.example.com]
@@ -130,7 +130,7 @@ repeating the path, so changing `ca_server_password_file` moves both the unit's
 ## More
 
 Full documentation, including the collection's modules, is in the
-[collection README](https://github.com/matonb/step/blob/main/README.md).
+[collection README](https://github.com/matonb/smallstep/blob/main/README.md).
 
 ## License
 

--- a/roles/ca_server/meta/main.yml
+++ b/roles/ca_server/meta/main.yml
@@ -27,7 +27,7 @@ galaxy_info:
 
 # step_cli owns the smallstep repository and the step CLI. A CA host needs
 # both: the repository to install step-ca from, and the CLI because
-# matonb.step.initialize shells out to `step ca init`.
+# matonb.smallstep.initialize shells out to `step ca init`.
 #
 # It is a dependency rather than duplicated here because two roles defining one
 # repository is how they came to fight over the same file - each rewriting the
@@ -35,4 +35,4 @@ galaxy_info:
 # dependencies before this role's own tasks and once per play, so including
 # ca_server alone still gives a complete CA host.
 dependencies:
-  - role: matonb.step.step_cli
+  - role: matonb.smallstep.step_cli

--- a/roles/step_cli/README.md
+++ b/roles/step_cli/README.md
@@ -1,11 +1,11 @@
-# matonb.step.step_cli
+# matonb.smallstep.step_cli
 
 Installs the [step CLI](https://smallstep.com/docs/step-cli/), and owns the
 smallstep package repository both roles in this collection install from.
 
 Use it directly on hosts that talk to a CA rather than run one.
-`matonb.step.ca_server` pulls it in for you, so a CA host does not need to name
-it.
+`matonb.smallstep.ca_server` pulls it in for you, so a CA host does not need to
+name it.
 
 ## Requirements
 
@@ -81,7 +81,7 @@ None.
 - name: Install the step CLI on hosts that talk to the CA
   hosts: clients
   roles:
-    - matonb.step.step_cli
+    - matonb.smallstep.step_cli
 ```
 
 Pinning a version, and installing from a mirror you manage yourself:
@@ -90,7 +90,7 @@ Pinning a version, and installing from a mirror you manage yourself:
 - name: Install a pinned step CLI from our own repository
   hosts: clients
   roles:
-    - role: matonb.step.step_cli
+    - role: matonb.smallstep.step_cli
       vars:
         step_cli_manage_repository: false
         step_cli_version: "0.30.6-1"
@@ -99,7 +99,7 @@ Pinning a version, and installing from a mirror you manage yourself:
 ## More
 
 Full documentation, including the collection's modules, is in the
-[collection README](https://github.com/matonb/step/blob/main/README.md).
+[collection README](https://github.com/matonb/smallstep/blob/main/README.md).
 
 ## License
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -2,7 +2,7 @@
 
 Two suites, for the two halves of the collection.
 
-`run.sh` drives `matonb.step.provisioner` against real `step-ca` instances, one
+`run.sh` drives `matonb.smallstep.provisioner` against real `step-ca` instances, one
 in each management mode. `role.sh` drives the `ca_server` role against
 containers running a real PID 1 systemd. Unit tests cannot prove that a flag is
 accepted by the real binary, that an Admin API change reaches the running CA, or
@@ -51,7 +51,7 @@ Every task runs **without reloading first**, which is the point. Add, re-add,
 reconcile a claim and remove all happen against a CA whose loaded configuration
 is stale, proving the module compares against `ca.json` — the file it writes —
 rather than against the CA. This is the regression test for
-[#31](https://github.com/matonb/step/issues/31); before the fix the second add
+[#31](https://github.com/matonb/smallstep/issues/31); before the fix the second add
 failed with `provisioner with name acme already exists`. A single `SIGHUP` at
 the end confirms the CA converges on exactly what `ca.json` holds.
 

--- a/tests/integration/admin_mode.yml
+++ b/tests/integration/admin_mode.yml
@@ -29,7 +29,7 @@
       register: ca_json_before
 
     - name: Missing admin credentials must fail immediately, not hang
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         ca_config: "{{ ca_dir }}/ca.json"
         ca_url: "{{ ca_url }}"
         name: neverbuilt
@@ -47,7 +47,7 @@
           Expected incomplete admin credentials to be rejected before step ran
 
     - name: Add an ACME provisioner (check mode)
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: acme
         type: ACME
@@ -55,14 +55,14 @@
       register: acme_check
 
     - name: Add an ACME provisioner
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: acme
         type: ACME
       register: acme_add
 
     - name: Add it again
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: acme
         type: ACME
@@ -79,7 +79,7 @@
         fail_msg: "Admin mode add/idempotence/restart_required incorrect"
 
     - name: Add a JWK provisioner with claims
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: cicd
         type: JWK
@@ -89,7 +89,7 @@
       register: jwk_add
 
     - name: Add it again
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: cicd
         type: JWK
@@ -147,7 +147,7 @@
           The generated provisioner password did not yield a certificate
 
     - name: Change a claim
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: cicd
         type: JWK
@@ -179,14 +179,14 @@
           The Admin API change is not visible in the running CA
 
     - name: Remove the ACME provisioner
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: acme
         state: absent
       register: acme_remove
 
     - name: Remove it again
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: acme
         state: absent

--- a/tests/integration/config_mode.yml
+++ b/tests/integration/config_mode.yml
@@ -34,7 +34,7 @@
       root: "{{ ca_dir }}/certs/root_ca.crt"
   tasks:
     - name: Add an ACME provisioner (check mode)
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: acme
         type: ACME
@@ -48,7 +48,7 @@
       failed_when: false
 
     - name: Add an ACME provisioner
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: acme
         type: ACME
@@ -69,7 +69,7 @@
     # nothing, tries to create acme a second time, and step refuses with
     # "provisioner with name acme already exists" - failing this task.
     - name: Re-add immediately, without reloading the CA
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: acme
         type: ACME
@@ -99,7 +99,7 @@
           is still unaware of the change
 
     - name: Add a JWK provisioner with a claim
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: cicd
         type: JWK
@@ -107,7 +107,7 @@
       register: jwk_add
 
     - name: Re-run with the same claim, still without a reload
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: cicd
         type: JWK
@@ -115,7 +115,7 @@
       register: jwk_again
 
     - name: Change the claim, still without a reload
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: cicd
         type: JWK
@@ -136,7 +136,7 @@
     # does not see acme in the CA's loaded configuration, so it reports ok and
     # leaves the provisioner in ca.json.
     - name: Remove the ACME provisioner, still without a reload
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: acme
         state: absent
@@ -187,14 +187,14 @@
       changed_when: true
 
     - name: Add a provisioner with no CA running at all
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: offline
         type: ACME
       register: offline_add
 
     - name: Re-run with the CA still down
-      matonb.step.provisioner:
+      matonb.smallstep.provisioner:
         <<: *conn
         name: offline
         type: ACME

--- a/tests/integration/role.sh
+++ b/tests/integration/role.sh
@@ -237,7 +237,7 @@ assert_handler_ran() {
 assert_task_ran() {
     local task=$1 outcome
     outcome="$(sed 's/\x1b\[[0-9;]*m//g' "$WORK/last.log" |
-        grep -A3 -E "TASK \[matonb\.step\.[a-z_]+ : $task\]" |
+        grep -A3 -E "TASK \[matonb\.smallstep\.[a-z_]+ : $task\]" |
         grep -m1 -oE '^(changed|ok|skipping|fatal):' || true)"
     case "$outcome" in
         changed: | ok:) ;;

--- a/tests/integration/role.sh
+++ b/tests/integration/role.sh
@@ -135,11 +135,11 @@ done <<<"$ROLE_VARS"
 DEB_SOURCES="/etc/apt/sources.list.d/$REPOSITORY_NAME.list"
 EL_REPO="/etc/yum.repos.d/$REPOSITORY_NAME.repo"
 
-# The role resolves as matonb.step.ca_server, so the checkout has to be
+# The role resolves as matonb.smallstep.ca_server, so the checkout has to be
 # reachable under that path. A symlink is enough for Ansible itself.
 COLLECTIONS="$WORK/collections"
 mkdir -p "$COLLECTIONS/ansible_collections/matonb"
-ln -s "$REPO_ROOT" "$COLLECTIONS/ansible_collections/matonb/step"
+ln -s "$REPO_ROOT" "$COLLECTIONS/ansible_collections/matonb/smallstep"
 
 # Prepended rather than assigned. This variable replaces the search path, it
 # does not add to it, so a bare assignment hides every collection the host
@@ -213,7 +213,7 @@ assert_changed() {
 # which is how the first version of this assertion managed to be vacuous. What
 # separates the two is the result line that follows it.
 assert_handler_ran() {
-    local banner="RUNNING HANDLER \[matonb.step.ca_server : $1\]" outcome
+    local banner="RUNNING HANDLER \[matonb.smallstep.ca_server : $1\]" outcome
     outcome="$(sed 's/\x1b\[[0-9;]*m//g' "$WORK/last.log" |
         grep -A3 -E "$banner" |
         grep -m1 -oE '^(changed|ok|skipping|fatal):' || true)"
@@ -268,8 +268,8 @@ assert_property() {
 
 start_host() {
     local family=$1 dockerfile=$2
-    local image="matonb-step-role-$family"
-    CONTAINER="matonb-step-it-role-$family"
+    local image="matonb-smallstep-role-$family"
+    CONTAINER="matonb-smallstep-it-role-$family"
     CONTAINERS+=("$CONTAINER")
 
     step "building the $family image"

--- a/tests/integration/role_ca_server.yml
+++ b/tests/integration/role_ca_server.yml
@@ -7,4 +7,4 @@
   gather_facts: true
 
   roles:
-    - matonb.step.ca_server
+    - matonb.smallstep.ca_server

--- a/tests/integration/role_initialize.yml
+++ b/tests/integration/role_initialize.yml
@@ -11,7 +11,7 @@
   # writes has to be the one the unit's ConditionFileNotEmpty names, and
   # hardcoding the path here would let the two drift and still pass.
   roles:
-    - matonb.step.ca_server
+    - matonb.smallstep.ca_server
 
   tasks:
     - name: Write the CA password
@@ -26,7 +26,7 @@
     - name: Initialize the CA
       become: true
       become_user: step
-      matonb.step.initialize:
+      matonb.smallstep.initialize:
         name: Role Test CA
         path: /etc/step-ca
         dns:
@@ -46,7 +46,7 @@
     - name: Running it again reports ok, not failure
       become: true
       become_user: step
-      matonb.step.initialize:
+      matonb.smallstep.initialize:
         name: Role Test CA
         path: /etc/step-ca
         dns:

--- a/tests/integration/role_reload.yml
+++ b/tests/integration/role_reload.yml
@@ -7,7 +7,7 @@
   gather_facts: true
 
   roles:
-    - matonb.step.ca_server
+    - matonb.smallstep.ca_server
 
   tasks:
     - name: Stand in for a ca.json change

--- a/tests/integration/role_step_cli.yml
+++ b/tests/integration/role_step_cli.yml
@@ -6,7 +6,7 @@
   gather_facts: true
 
   roles:
-    - matonb.step.step_cli
+    - matonb.smallstep.step_cli
 
   tasks:
     - name: The step CLI is on PATH and runs

--- a/tests/integration/run.sh
+++ b/tests/integration/run.sh
@@ -12,8 +12,8 @@
 set -euo pipefail
 
 IMAGE="${STEP_TEST_IMAGE:-smallstep/step-ca:latest}"
-ADMIN_CONTAINER="matonb-step-it-admin"
-CONFIG_CONTAINER="matonb-step-it-config"
+ADMIN_CONTAINER="matonb-smallstep-it-admin"
+CONFIG_CONTAINER="matonb-smallstep-it-config"
 ADMIN_PORT="${STEP_TEST_ADMIN_PORT:-9101}"
 CONFIG_PORT="${STEP_TEST_CONFIG_PORT:-9102}"
 CA_PASSWORD="integration-test-password"
@@ -63,11 +63,11 @@ require ansible-playbook
 # fail outright.
 docker rm -f "$ADMIN_CONTAINER" "$CONFIG_CONTAINER" >/dev/null 2>&1 || true
 
-# The module resolves `ansible_collections.matonb.step...`, so the checkout has
+# The module resolves `ansible_collections.matonb.smallstep...`, so the checkout has
 # to be reachable under that path. A symlink is enough for Ansible itself.
 COLLECTIONS="$WORK/collections"
 mkdir -p "$COLLECTIONS/ansible_collections/matonb"
-ln -s "$REPO_ROOT" "$COLLECTIONS/ansible_collections/matonb/step"
+ln -s "$REPO_ROOT" "$COLLECTIONS/ansible_collections/matonb/smallstep"
 export ANSIBLE_COLLECTIONS_PATH="$COLLECTIONS"
 
 wait_for_ca() {

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,7 +3,7 @@
 """Make the collection importable when pytest is run directly.
 
 Modules import their shared code as
-``ansible_collections.matonb.step.plugins.module_utils.*``, which only resolves
+``ansible_collections.matonb.smallstep.plugins.module_utils.*``, which only resolves
 when the collection sits in an ``ansible_collections/<namespace>/<name>``
 directory. ``ansible-test units`` arranges that itself; a developer running
 ``pytest tests/unit`` from a clone does not, because the clone is usually named
@@ -30,7 +30,7 @@ import sys
 
 import pytest
 
-COLLECTION = ("matonb", "step")
+COLLECTION = ("matonb", "smallstep")
 CACHE_DIR = ".pytest-collection-root"
 
 

--- a/tests/unit/plugins/module_utils/test_connection.py
+++ b/tests/unit/plugins/module_utils/test_connection.py
@@ -14,7 +14,7 @@ import subprocess
 
 import pytest
 
-from ansible_collections.matonb.step.plugins.module_utils.connection import (
+from ansible_collections.matonb.smallstep.plugins.module_utils.connection import (
     _COMMAND_FLAGS,
     _FLAG_NAMES,
     AdminCredentials,

--- a/tests/unit/plugins/module_utils/test_process.py
+++ b/tests/unit/plugins/module_utils/test_process.py
@@ -9,7 +9,7 @@ import subprocess
 
 import pytest
 
-from ansible_collections.matonb.step.plugins.module_utils.process import (
+from ansible_collections.matonb.smallstep.plugins.module_utils.process import (
     CommandTimeoutError,
     _create_completed_process,
     _demotion_hook,

--- a/tests/unit/plugins/module_utils/test_provisioner.py
+++ b/tests/unit/plugins/module_utils/test_provisioner.py
@@ -9,8 +9,8 @@ import subprocess
 
 import pytest
 
-from ansible_collections.matonb.step.plugins.module_utils.connection import ManagementMode, StepConnection
-from ansible_collections.matonb.step.plugins.module_utils.provisioner import (
+from ansible_collections.matonb.smallstep.plugins.module_utils.connection import ManagementMode, StepConnection
+from ansible_collections.matonb.smallstep.plugins.module_utils.provisioner import (
     COMMAND_TIMEOUT,
     X509_CLAIMS,
     ACMEProvisioner,

--- a/tests/unit/plugins/module_utils/test_utils.py
+++ b/tests/unit/plugins/module_utils/test_utils.py
@@ -10,7 +10,7 @@ import stat
 
 import pytest
 
-from ansible_collections.matonb.step.plugins.module_utils.utils import (
+from ansible_collections.matonb.smallstep.plugins.module_utils.utils import (
     generate_secure_password,
     parse_duration,
     save_json_file,

--- a/tests/unit/plugins/modules/test_configure.py
+++ b/tests/unit/plugins/modules/test_configure.py
@@ -14,8 +14,8 @@ import stat
 
 import pytest
 
-from ansible_collections.matonb.step.plugins.modules import configure
-from ansible_collections.matonb.step.plugins.modules.configure import (
+from ansible_collections.matonb.smallstep.plugins.modules import configure
+from ansible_collections.matonb.smallstep.plugins.modules.configure import (
     CLAIM_KEYS,
     TOP_LEVEL_KEYS,
     apply_updates,

--- a/tests/unit/plugins/modules/test_initialize.py
+++ b/tests/unit/plugins/modules/test_initialize.py
@@ -7,8 +7,8 @@ import os
 
 import pytest
 
-from ansible_collections.matonb.step.plugins.modules import initialize
-from ansible_collections.matonb.step.plugins.modules.initialize import (
+from ansible_collections.matonb.smallstep.plugins.modules import initialize
+from ansible_collections.matonb.smallstep.plugins.modules.initialize import (
     CA_FILE_NAMES,
     build_initialize_command,
     configured_paths,

--- a/tests/unit/plugins/modules/test_provisioner.py
+++ b/tests/unit/plugins/modules/test_provisioner.py
@@ -7,12 +7,12 @@ import subprocess
 
 import pytest
 
-from ansible_collections.matonb.step.plugins.module_utils.connection import ManagementMode
-from ansible_collections.matonb.step.plugins.module_utils.provisioner import (
+from ansible_collections.matonb.smallstep.plugins.module_utils.connection import ManagementMode
+from ansible_collections.matonb.smallstep.plugins.module_utils.provisioner import (
     StepProvisionerClient,
     build_provisioner,
 )
-from ansible_collections.matonb.step.plugins.modules.provisioner import (
+from ansible_collections.matonb.smallstep.plugins.modules.provisioner import (
     apply_absent,
     apply_present,
     build_connection,
@@ -92,12 +92,12 @@ class TestArgumentSpec:
         spec = get_argument_spec()["root"]
         assert spec["aliases"] == ["ca_root"]
         assert spec["deprecated_aliases"][0]["name"] == "ca_root"
-        assert spec["deprecated_aliases"][0]["collection_name"] == "matonb.step"
+        assert spec["deprecated_aliases"][0]["collection_name"] == "matonb.smallstep"
 
     def test_fingerprint_is_marked_for_removal(self):
         spec = get_argument_spec()["fingerprint"]
         assert spec["removed_in_version"]
-        assert spec["removed_from_collection"] == "matonb.step"
+        assert spec["removed_from_collection"] == "matonb.smallstep"
 
     @pytest.mark.parametrize("option", ["admin_key", "admin_password_file"])
     def test_path_options_opt_out_of_the_no_log_heuristic(self, option):


### PR DESCRIPTION
Renames the collection and the GitHub repository to `smallstep`, updating every FQCN, import path, workflow checkout path and metadata URL to match — 199 references across 33 files.

The old `matonb.step` collection was deleted from Galaxy, so there are no consumers and no deprecation shim is needed.

## Also in this change

**`bootstrap` → `config_info`.** The module reads a JSON configuration file and returns its contents; the old name did not describe that. Follows the `_info` convention for read-only modules and pairs with `configure`, which writes the same file.

**Lint gates the release.** `lint.yml` gains `workflow_call` and loses `push: main`; `release.yml` gains a `lint` job. Previously lint ran on push to main in parallel with the release, so a version could be tagged while lint was red. It deliberately does *not* depend on `preflight` — whether a Galaxy token exists has no bearing on whether the code lints, and coupling them would leave a push unlinted if the secret were ever missing.

```
preflight ──┬── test ────────┐
            └── integration ─┤
lint ────────────────────────┴── release ── publish
```

**README** gains a Release badge. One badge rather than several: the called workflows produce no runs of their own, so a badge for them would freeze or read "no status".

## Verification

- Built `matonb-smallstep-1.4.1.tar.gz` and ran **galaxy-importer 0.4.41** against it → import completes, modules load as `config_info`/`configure`/`initialize`/`provisioner`, both roles load
- `pytest tests/unit -q` → 403 passed
- `pre-commit run --all-files` → passes
- `actionlint` → clean on all changed workflows
- Swept all four old-name forms (`matonb.step`, `matonb/step`, `matonb-step`, `matonb_step`) across tracked *and* gitignored files → 0 remaining
- Confirmed `step_cli`, `step-ca` and the `step` system user were not caught by the rename

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C3SLgdmivJsGkd6xYbv3k2