### PR TITLE
fix(docs): correct the licence stated

### DIFF
--- a/README.md
+++ b/README.md
@@ -664,7 +664,7 @@ else. Neither gates a merge, but both gate a release.
 
 ## License
 
-MIT
+GPL-3.0-or-later
 
 ## Author Information
 


### PR DESCRIPTION
The README's `## License` section said `MIT`. Every authoritative source in
the repo says GPL-3.0-or-later: `LICENSE`, `galaxy.yml`, `pyproject.toml`,
`meta/runtime.yml`, all four module headers and both role `meta/main.yml`
files, plus the README's own badge and both role READMEs.

The README ships in the collection tarball, so the wrong claim is currently
published on Galaxy in 1.4.2.

Typed `fix` rather than `docs` deliberately: semantic-release bumps only on
`feat`/`fix`/`perf`, so a `docs` commit would leave the incorrect licence
published until some unrelated change triggered the next release.